### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,0 +1,2 @@
+# exercise readme insert
+

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Zig is a general-purpose programming language equipped with well-rounded toolchains that aims to be simple and familiar, yet disparate from what programmers rely on today. Its main attributes involve helping programmers to develop **robust**, **optimal**, and **reusable** software. All the while, Zig aims to remedy the design problems of older languages with features that promote safety through the use of [optionals][optionals], a unique take on [error handling][error-handling], and [compile-time execution][compile-time].
 
 From the ground up, Zig was designed to be competitive with other systems programming languages and not be reliant on them. With bold claims such as, "Zig is faster than C" featured on it's home page, being independent from other languages is a major design philosophy that it champions.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 There are many ways to install Zig, and the number of ways to install Zig are steadily increasing as the language matures. Fortunately, all of the popular installation methods are listed on the [Zig install page][install-zig].
 
 ## Additional utilities

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 * [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
 * [Awesome Zig][awesome-zig] is a good collection of Zig projects made by various people. The collection features projects involving well developed Zig code.
 * [Zig Launch][zig-launch] is a assortment of Zig examples that demonstrates very specific Zig features.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
 * [The Zig Standard Library][std] is a good reference to learn how Zig code is written and shows many of the functions that you could import into your own code.
 * [#zig][irc] on irc.freenode.net is the main Zig IRC channel.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -4,7 +4,7 @@ Write your code in `<exercise-name>.zig`. Some exercises come with prewritten si
 
 These prewritten signatures are meant to help you towards completing exercises by providing a clear starting point. However, starting from these signatures is not necessary. Especially when any written code which passes their tests are perfectly acceptable solutions.
 
-### Running Tests
+## Running Tests
 
 To run the tests, all you need to do is run the following command:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Writing the Code
+# Writing the Code
 
 Write your code in `<exercise-name>.zig`. Some exercises come with prewritten signatures for specific Zig constructs, such as [constants][constants], [functions][functions], [imports][imports], [structs][structs], and [potentially many more][et-cetera]!
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
