### PR TITLE
Add Zig related miscellaneous information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 bin/configlet
 bin/configlet.exe
+zig-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: bash
-
-script:
-  - bin/fetch-configlet
-  - bin/configlet lint --track-id zig .

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-  "track_id": "zig",
   "language": "Zig",
   "slug": "zig",
   "active": false,
@@ -9,20 +8,39 @@
     "representer": false,
     "analyzer": false
   },
-  "blurb": "",
+  "blurb": "Zig is a general-purpose programming language equipped with well-rounded toolchains that aims to be simple and familiar, yet disparate from what programmers rely on today.",
   "version": 3,
   "online_editor": {
     "indent_style": "space",
     "indent_size": 4
   },
-  "ignore_pattern": "[Ee]xample",
-  "solution_pattern": "[Ee]xample",
-  "test_pattern": "[Tt]est",
   "exercises": {
     "concept": [],
     "practice": []
   },
   "concepts": [],
   "key_features": [],
-  "tags": []
+  "tags": [
+    "paradigm/imperative",
+    "paradigm/procedural",
+    "typing/static",
+    "typing/weak",
+    "execution_mode/compiled",
+    "platform/windows",
+    "platform/mac",
+    "platform/linux",
+    "platform/ios",
+    "platform/android",
+    "platform/web",
+    "runtime/standalone_executable",
+    "used_for/backends",
+    "used_for/cross_platform_development",
+    "used_for/embedded_systems",
+    "used_for/financial_systems",
+    "used_for/frontends",
+    "used_for/games",
+    "used_for/robotics",
+    "used_for/scientific_calculations",
+    "used_for/web_development"
+  ]
 }


### PR DESCRIPTION
This pull request adds the following:

- zig-cache directories are ignored, so files involving compilation output are never accidentally pushed onto the repo. 
- The repo's config.js file now contains some Zig related information, including tags. Thus, this pull request should resolve issue #14 entirely.
- Finally, the .travis.yml file has been removed. This is the first step towards resolving issue #2.