### PR TITLE
Add hello-world practice exercise

### DIFF
--- a/_test/run-tests.sh
+++ b/_test/run-tests.sh
@@ -13,8 +13,14 @@ execute_test () {
         # Copy the examples with the correct name for the exercise
         if [ -e "./.meta/example.zig" ]; then
             mv ./.meta/example.zig "${EXERCISE_NAME}".zig
-            # No building required, just test it.
-            zig test test_${EXERCISE_NAME}.zig
+            # No building required, just test it
+            if [ -L "$HOME/bin/zig" ]; then
+                # Zig track repo symlinks zig to this location
+                $HOME/bin/zig test test_${EXERCISE_NAME}.zig
+            else
+                # Otherwise zig should be on your $PATH
+                zig test test_${EXERCISE_NAME}.zig
+            fi
             printf '\n'
         else
             printf '%s\n' \

--- a/config.json
+++ b/config.json
@@ -16,7 +16,26 @@
   },
   "exercises": {
     "concept": [],
-    "practice": []
+    "practice": [
+      {
+        "uuid": "25a0331e-612f-48c1-8a3f-9b0e9601a2fa",
+        "slug": "hello-world",
+        "name": "Hello, World!",
+        "practices": [
+          "functions",
+          "slices",
+          "strings",
+          "type-coercion"
+        ],
+        "prerequisites": [
+          "functions",
+          "slices",
+          "strings",
+          "type-coercion"
+        ],
+        "difficulty": 1
+      }
+    ]
   },
   "concepts": [],
   "key_features": [],

--- a/exercises/practice/hello-world/.docs/instructions.md
+++ b/exercises/practice/hello-world/.docs/instructions.md
@@ -1,0 +1,15 @@
+# Instructions
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "hello_world.zig"
+    ],
+    "test": [
+      "test_hello_world.zig"
+    ]
+  },
+  "source": "This is an exercise to introduce users to using Exercism",
+  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+}

--- a/exercises/practice/hello-world/.meta/example.zig
+++ b/exercises/practice/hello-world/.meta/example.zig
@@ -1,0 +1,3 @@
+pub fn hello() []const u8 {
+    return "Hello, world!";
+}

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,4 @@
+[canonical-tests]
+
+# Say Hi!
+"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,4 +1,7 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"
+include = true

--- a/exercises/practice/hello-world/hello_world.zig
+++ b/exercises/practice/hello-world/hello_world.zig
@@ -1,0 +1,3 @@
+pub fn hello() []const u8 {
+    return "Goodbye, world!";
+}

--- a/exercises/practice/hello-world/test_hello_world.zig
+++ b/exercises/practice/hello-world/test_hello_world.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const testing = std.testing;
+
+const hello_world = @import("hello_world.zig");
+
+test "say hi" {
+    const expected = "Hello, world!";
+    const actual = comptime hello_world.hello();
+    comptime testing.expectEqualStrings(expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard hello-world practice exercise.

**Note**: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.