### PR TITLE
Add two-fer practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,6 +34,26 @@
           "type-coercion"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "866a09d8-6949-4363-b83f-7b9fefb53893",
+        "slug": "two-fer",
+        "name": "Two Fer",
+        "practices": [
+          "conditionals",
+          "errors",
+          "functions",
+          "optionals",
+          "slices"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "errors",
+          "functions",
+          "optionals",
+          "slices"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/two-fer/.docs/instructions.md
+++ b/exercises/practice/two-fer/.docs/instructions.md
@@ -1,0 +1,26 @@
+# Description
+
+`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+
+Given a name, return a string with the message:
+
+```text
+One for name, one for me.
+```
+
+Where "name" is the given name.
+
+However, if the name is missing, return the string:
+
+```text
+One for you, one for me.
+```
+
+Here are some examples:
+
+|Name    |String to return
+|:-------|:------------------
+|Alice   |One for Alice, one for me.
+|Bob     |One for Bob, one for me.
+|        |One for you, one for me.
+|Zaphod  |One for Zaphod, one for me.

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,0 +1,21 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "two_fer.zig"
+    ],
+    "test": [
+      "test_two_fer.zig"
+    ]
+  },
+  "source_url": "https://github.com/exercism/problem-specifications/issues/757"
+}

--- a/exercises/practice/two-fer/.meta/example.zig
+++ b/exercises/practice/two-fer/.meta/example.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const fmt = std.fmt;
+
+pub fn two_fer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
+    var word = if (name == null) "me" else name;
+    var slice = try fmt.bufPrint(buffer, "One for {}, one for you.", .{word});
+    return slice;
+}

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,0 +1,10 @@
+[canonical-tests]
+
+# no name given
+"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+
+# a name given
+"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+
+# another name given
+"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,10 +1,15 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+include = true
 
-# a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+include = true
 
-# another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"
+include = true

--- a/exercises/practice/two-fer/test_two_fer.zig
+++ b/exercises/practice/two-fer/test_two_fer.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const testing = std.testing;
+
+const two_fer = @import("two_fer.zig");
+
+const BUFFER_SIZE = 100;
+
+test "no name given" {
+    var response: [BUFFER_SIZE]u8 = undefined;
+    const expected = "One for me, one for you.";
+    const actual = try two_fer.two_fer(&response, null);
+    testing.expectEqualStrings(expected, actual);
+}
+
+test "a name given" {
+    var response: [BUFFER_SIZE]u8 = undefined;
+    const expected = "One for Alice, one for you.";
+    const actual = try two_fer.two_fer(&response, "Alice");
+    testing.expectEqualStrings(expected, actual);
+}
+
+test "another name given" {
+    var response: [BUFFER_SIZE]u8 = undefined;
+    const expected = "One for Bob, one for you.";
+    const actual = try two_fer.two_fer(&response, "Bob");
+    testing.expectEqualStrings(expected, actual);
+}

--- a/exercises/practice/two-fer/two_fer.zig
+++ b/exercises/practice/two-fer/two_fer.zig
@@ -1,0 +1,3 @@
+pub fn two_fer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
+    @panic("respond with the appropriate message given a particular name");
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard two-fer practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.