### PR TITLE
Add resistor-color practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,6 +54,28 @@
           "slices"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "52a244a4-205d-4fb3-8725-2f31fbc0a0b8",
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "practices": [
+          "arrays",
+          "builtin-functions",
+          "enums",
+          "functions",
+          "pointers",
+          "slices"
+        ],
+        "prerequisites": [
+          "arrays",
+          "builtin-functions",
+          "enums",
+          "functions",
+          "pointers",
+          "slices"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -1,0 +1,35 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+* Each resistor has a resistance value.
+* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+The goal of this exercise is to create a way:
+- to look up the numerical value associated with a particular color band
+- to list the different band colors
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -7,14 +7,14 @@
   ],
   "blurb": "Convert a resistor band's color to its numeric representation",
   "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
     "solution": [
       "resistor_color.zig"
     ],
     "test": [
       "test_resistor_color.zig"
-    ],
-    "example": [
-      ".meta/example.zig"
     ]
   },
   "source": "Maud de Vries, Erik Schierboom",

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Convert a resistor band's color to its numeric representation",
+  "files": {
+    "solution": [
+      "resistor_color.zig"
+    ],
+    "test": [
+      "test_resistor_color.zig"
+    ],
+    "example": [
+      ".meta/example.zig"
+    ]
+  },
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
+}

--- a/exercises/practice/resistor-color/.meta/example.zig
+++ b/exercises/practice/resistor-color/.meta/example.zig
@@ -1,0 +1,25 @@
+pub const ColorBand = enum(u4) {
+    black,
+    brown,
+    red,
+    orange,
+    yellow,
+    green,
+    blue,
+    violet,
+    grey,
+    white,
+};
+
+const band_colors = [_]ColorBand{
+    .black, .brown, .red, .orange, .yellow,
+    .green, .blue, .violet, .grey, .white,
+};
+
+pub fn color_code(color: ColorBand) isize {
+    return @enumToInt(color);
+}
+
+pub fn colors() []const ColorBand {
+    return &band_colors;
+}

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -1,0 +1,19 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[49eb31c5-10a8-4180-9f7f-fea632ab87ef]
+description = "Black"
+include = true
+
+[0a4df94b-92da-4579-a907-65040ce0b3fc]
+description = "White"
+include = true
+
+[5f81608d-f36f-4190-8084-f45116b6f380]
+description = "Orange"
+include = true
+
+[581d68fa-f968-4be2-9f9d-880f2fb73cf7]
+description = "Colors"
+include = true

--- a/exercises/practice/resistor-color/resistor_color.zig
+++ b/exercises/practice/resistor-color/resistor_color.zig
@@ -1,0 +1,7 @@
+pub fn color_code(color: ColorBand) isize {
+    @panic("determine the value of a colorband on a resistor");
+}
+
+pub fn colors() []const ColorBand {
+    @panic("refer to a collection of all resistor colorbands");
+}

--- a/exercises/practice/resistor-color/test_resistor_color.zig
+++ b/exercises/practice/resistor-color/test_resistor_color.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const testing = std.testing;
+
+const resistor_color = @import("resistor_color.zig");
+const ColorBand = resistor_color.ColorBand;
+
+test "test black" {
+    const expected = 0;
+    const actual = comptime resistor_color.color_code(.black);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "test white" {
+    const expected = 9;
+    const actual = comptime resistor_color.color_code(.white);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "test orange" {
+    const expected = 3;
+    const actual = comptime resistor_color.color_code(.orange);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "test colors" {
+    const expected = &[_]ColorBand{
+        .black, .brown, .red, .orange, .yellow,
+        .green, .blue, .violet, .grey, .white,
+    };
+    const actual = comptime resistor_color.colors();
+    comptime testing.expectEqualSlices(ColorBand, expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard resistor-color practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.