### PR TITLE
Add difference-of-squares practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,6 +54,20 @@
           "slices"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "7f1ae5db-82f6-44b0-a5b4-a206f29c4bb0",
+        "slug": "difference-of-squares",
+        "name": "Difference of Squares",
+        "practices": [
+          "builtin-functions",
+          "functions"
+        ],
+        "prerequisites": [
+          "builtin-functions",
+          "functions"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -1,0 +1,17 @@
+# Description
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+You are not expected to discover an efficient solution to this yourself from
+first principles; research is allowed, indeed, encouraged. Finding the best
+algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "difference_of_squares.zig"
+    ],
+    "test": [
+      "test_difference_of_squares.zig"
+    ]
+  },
+  "source": "Problem 6 at Project Euler",
+  "source_url": "http://projecteuler.net/problem=6"
+}

--- a/exercises/practice/difference-of-squares/.meta/example.zig
+++ b/exercises/practice/difference-of-squares/.meta/example.zig
@@ -1,0 +1,12 @@
+pub fn square_of_sum(number: isize) isize {
+    var result = @divExact(number * (number + 1), 2);
+    return result * result;
+}
+
+pub fn sum_of_squares(number: isize) isize {
+    return @divExact(number * (number + 1) * (2 * number + 1), 6);
+}
+
+pub fn difference_of_squares(number: isize) isize {
+    return square_of_sum(number) - sum_of_squares(number);
+}

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,39 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "square of sum 1"
+include = true
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "square of sum 5"
+include = true
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "square of sum 100"
+include = true
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "sum of squares 1"
+include = true
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "sum of squares 5"
+include = true
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "sum of squares 100"
+include = true
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "difference of squares 1"
+include = true
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "difference of squares 5"
+include = true
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "difference of squares 100"
+include = true

--- a/exercises/practice/difference-of-squares/difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/difference_of_squares.zig
@@ -1,0 +1,11 @@
+pub fn square_of_sum(number: isize) isize {
+    @panic("compute the sum of i from 0 to n then square it");
+}
+
+pub fn sum_of_squares(number: isize) isize {
+    @panic("compute the sum of i^2 from 0 to n");
+}
+
+pub fn difference_of_squares(number: isize) isize {
+    @panic("compute the difference between the square of sum and sum of squares");
+}

--- a/exercises/practice/difference-of-squares/test_difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/test_difference_of_squares.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const testing = std.testing;
+
+const difference_of_squares = @import("difference_of_squares.zig");
+
+test "square of sum up to 1" {
+    const expected = 1;
+    const actual = comptime difference_of_squares.square_of_sum(1);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "square of sum up to 5" {
+    const expected = 225;
+    const actual = comptime difference_of_squares.square_of_sum(5);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "square of sum up to 100" {
+    const expected = 25502500;
+    const actual = comptime difference_of_squares.square_of_sum(100);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "sum of squares up to 1" {
+    const expected = 1;
+    const actual = comptime difference_of_squares.sum_of_squares(1);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "sum of squares up to 5" {
+    const expected = 55;
+    const actual = comptime difference_of_squares.sum_of_squares(5);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "sum of squares up to 100" {
+    const expected = 338350;
+    const actual = comptime difference_of_squares.sum_of_squares(100);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "difference of squares up to 1" {
+    const expected = 0;
+    const actual = comptime difference_of_squares.difference_of_squares(1);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "difference of squares up to 5" {
+    const expected = 170;
+    const actual = comptime difference_of_squares.difference_of_squares(5);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "difference of squares up to 100" {
+    const expected = 25164150;
+    const actual = comptime difference_of_squares.difference_of_squares(100);
+    comptime testing.expectEqual(expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard difference-of-squares practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.