### PR TITLE
Add grains practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -106,6 +106,26 @@
           "functions"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "dff58791-4373-46ec-933a-ea27a28b4486",
+        "slug": "grains",
+        "name": "Grains",
+        "practices": [
+          "bitwise-operations",
+          "builtin-functions",
+          "conditionals",
+          "error-sets",
+          "functions"
+        ],
+        "prerequisites": [
+          "bitwise-operations",
+          "builtin-functions",
+          "conditionals",
+          "error-sets",
+          "functions"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/grains/.docs/instructions.md
+++ b/exercises/practice/grains/.docs/instructions.md
@@ -1,0 +1,27 @@
+# Grains
+
+Calculate the number of grains of wheat on a chessboard given that the number
+on each square doubles.
+
+There once was a wise servant who saved the life of a prince. The king
+promised to pay whatever the servant could dream up. Knowing that the
+king loved chess, the servant told the king he would like to have grains
+of wheat. One grain on the first square of a chess board, with the number
+of grains doubling on each successive square.
+
+There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
+
+Write code that shows:
+- how many grains were on a given square, and
+- the total number of grains on the chessboard
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- Optimize for speed.
+- Optimize for readability.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "grains.zig"
+    ],
+    "test": [
+      "test_grains.zig"
+    ]
+  },
+  "source": "JavaRanch Cattle Drive, exercise 6",
+  "source_url": "http://www.javaranch.com/grains.jsp"
+}

--- a/exercises/practice/grains/.meta/example.zig
+++ b/exercises/practice/grains/.meta/example.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const math = std.math;
+
+pub const ChessboardError = error{IndexOutOfBounds};
+
+const NUMBER_OF_CHESS_SQUARES = 64;
+
+pub fn square(index: isize) ChessboardError!u64 {
+    if (index > NUMBER_OF_CHESS_SQUARES or index <= 0) {
+        return ChessboardError.IndexOutOfBounds;
+    }
+    return @as(u64, 1) << @truncate(u6, @bitCast(usize, index) - 1);
+}
+
+pub fn total() u64 {
+    return math.maxInt(u64);
+}

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -1,0 +1,47 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[9fbde8de-36b2-49de-baf2-cd42d6f28405]
+description = "grains on square 1"
+include = true
+
+[ee1f30c2-01d8-4298-b25d-c677331b5e6d]
+description = "grains on square 2"
+include = true
+
+[10f45584-2fc3-4875-8ec6-666065d1163b]
+description = "grains on square 3"
+include = true
+
+[a7cbe01b-36f4-4601-b053-c5f6ae055170]
+description = "grains of square 4"
+include = true
+
+[c50acc89-8535-44e4-918f-b848ad2817d4]
+description = "grains on square 16"
+include = true
+
+[acd81b46-c2ad-4951-b848-80d15ed5a04f]
+description = "grains on square 32"
+include = true
+
+[c73b470a-5efb-4d53-9ac6-c5f6487f227b]
+description = "grains on square 64"
+include = true
+
+[1d47d832-3e85-4974-9466-5bd35af484e3]
+description = "square 0 raises an exception"
+include = true
+
+[61974483-eeb2-465e-be54-ca5dde366453]
+description = "negative square raises an exception"
+include = true
+
+[a95e4374-f32c-45a7-a10d-ffec475c012f]
+description = "square greateer than 64 raises an exception"
+include = true
+
+[6eb07385-3659-4b45-a6be-9dc474222750]
+description = "returns the total number of grains on the board"
+include = true

--- a/exercises/practice/grains/grains.zig
+++ b/exercises/practice/grains/grains.zig
@@ -1,0 +1,7 @@
+pub fn square(index: isize) ChessboardError!u64 {
+    @panic("please implement the square function");
+}
+
+pub fn total() u64 {
+    @panic("please implement the total function");
+}

--- a/exercises/practice/grains/test_grains.zig
+++ b/exercises/practice/grains/test_grains.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const testing = std.testing;
+
+const grains = @import("grains.zig");
+const ChessboardError = grains.ChessboardError;
+
+test "grains on square 1" {
+    const expected = 1;
+    const actual = comptime try grains.square(1);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "grains on square 2" {
+    const expected = 2;
+    const actual = comptime try grains.square(2);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "grains on square 3" {
+    const expected = 4;
+    const actual = comptime try grains.square(3);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "grains on square 4" {
+    const expected = 8;
+    const actual = comptime try grains.square(4);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "grains on square 16" {
+    const expected = 32768;
+    const actual = comptime try grains.square(16);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "grains on square 32" {
+    const expected = 2147483648;
+    const actual = comptime try grains.square(32);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "grains on square 64" {
+    const expected = 9223372036854775808;
+    const actual = comptime try grains.square(64);
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "square 0 raises an exception" {
+    const expected = ChessboardError.IndexOutOfBounds;
+    const actual = comptime grains.square(0);
+    testing.expectError(expected, actual);
+}
+
+test "negative square raises an expection" {
+    const expected = ChessboardError.IndexOutOfBounds;
+    const actual = comptime grains.square(-1);
+    testing.expectError(expected, actual);
+}
+
+test "square greater than 64 raises an exception" {
+    const expected = ChessboardError.IndexOutOfBounds;
+    const actual = comptime grains.square(65);
+    testing.expectError(expected, actual);
+}
+
+test "returns the total number of grains on the board" {
+    const expected = 18446744073709551615;
+    const actual = comptime grains.total();
+    comptime testing.expectEqual(expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard grains practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.