### PR TITLE
Add resistor-color-duo practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,16 +56,17 @@
         "difficulty": 1
       },
       {
-        "uuid": "52a244a4-205d-4fb3-8725-2f31fbc0a0b8",
-        "slug": "resistor-color-duo",
-        "name": "Resistor Color Duo",
+        "uuid": "f49a0baa-a309-4814-a123-f41a2d770bdd",
+        "slug": "resistor-color",
+        "name": "Resistor Color",
         "practices": [
           "arrays",
           "builtin-functions",
           "enums",
           "functions",
           "pointers",
-          "slices"
+          "slices",
+          "type-coercion"
         ],
         "prerequisites": [
           "arrays",
@@ -73,7 +74,34 @@
           "enums",
           "functions",
           "pointers",
-          "slices"
+          "slices",
+          "type-coercion"
+        ],
+        "difficulty": 1
+      },
+      {
+        "uuid": "52a244a4-205d-4fb3-8725-2f31fbc0a0b8",
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "practices": [
+          "arrays",
+          "builtin-functions",
+          "enums",
+          "error-set",
+          "functions",
+          "pointers",
+          "slices",
+          "type-coercion"
+        ],
+        "prerequisites": [
+          "arrays",
+          "builtin-functions",
+          "enums",
+          "error-set",
+          "functions",
+          "pointers",
+          "slices",
+          "type-coercion"
         ],
         "difficulty": 1
       },

--- a/exercises/practice/resistor-color-duo/.docs/instructions.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.md
@@ -1,0 +1,33 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+* Each resistor has a resistance value.
+* Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+The program will take color names as input and output a two digit number, even if the input is more than two colors!
+
+The band colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+From the example above:
+brown-green should return 15
+brown-green-violet should return 15 too, ignoring the third color.

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "blurb": "Convert color codes, as used on resistors, to a numeric value.",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "resistor_color_duo.zig"
+    ],
+    "test": [
+      "test_resistor_color_duo.zig"
+    ]
+  },
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1464"
+}

--- a/exercises/practice/resistor-color-duo/.meta/example.zig
+++ b/exercises/practice/resistor-color-duo/.meta/example.zig
@@ -1,0 +1,24 @@
+pub const ColorBand = enum(u4) {
+    black,
+    brown,
+    red,
+    orange,
+    yellow,
+    green,
+    blue,
+    violet,
+    grey,
+    white,
+};
+
+pub const RuntimeError = error {
+    IllegalArgument,
+};
+
+pub fn color_code(colors: []const ColorBand) RuntimeError!isize {
+    if (colors.len < 2) {
+        return RuntimeError.IllegalArgument;
+    }
+    return @as(isize, @enumToInt(colors[0])) * 10
+        + @as(isize, @enumToInt(colors[1]));
+}

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -1,0 +1,23 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[ce11995a-5b93-4950-a5e9-93423693b2fc]
+description = "Brown and black"
+include = true
+
+[7bf82f7a-af23-48ba-a97d-38d59406a920]
+description = "Blue and grey"
+include = true
+
+[f1886361-fdfd-4693-acf8-46726fe24e0c]
+description = "Yellow and violet"
+include = true
+
+[77a8293d-2a83-4016-b1af-991acc12b9fe]
+description = "Orange and orange"
+include = true
+
+[0c4fb44f-db7c-4d03-afa8-054350f156a8]
+description = "Ignore additional colors"
+include = true

--- a/exercises/practice/resistor-color-duo/resistor_color_duo.zig
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo.zig
@@ -1,0 +1,3 @@
+pub fn color_code(colors: []const ColorBand) anyerror!isize {
+    @panic("please implement the color_code function");
+}

--- a/exercises/practice/resistor-color-duo/test_resistor_color_duo.zig
+++ b/exercises/practice/resistor-color-duo/test_resistor_color_duo.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const testing = std.testing;
+
+const resistor_color_duo = @import("resistor_color_duo.zig");
+const ColorBand = resistor_color_duo.ColorBand;
+
+test "brown and black" {
+    const array = [_]ColorBand{.brown, .black};
+    const expected = 10;
+    const actual = comptime try resistor_color_duo.color_code(&array);
+    testing.expectEqual(expected, actual);
+}
+
+test "blue and grey" {
+    const array = [_]ColorBand{.blue, .grey};
+    const expected = 68;
+    const actual = comptime try resistor_color_duo.color_code(&array);
+    testing.expectEqual(expected, actual);
+}
+
+test "yellow and violet" {
+    const array = [_]ColorBand{.yellow, .violet};
+    const expected = 47;
+    const actual = comptime try resistor_color_duo.color_code(&array);
+    testing.expectEqual(expected, actual);
+}
+
+test "orange and orange" {
+    const array = [_]ColorBand{.orange, .orange};
+    const expected = 33;
+    const actual = comptime try resistor_color_duo.color_code(&array);
+    testing.expectEqual(expected, actual);
+}
+
+test "ignore additional colors" {
+    const array = [_]ColorBand{.green, .brown, .orange};
+    const expected = 51;
+    const actual = comptime try resistor_color_duo.color_code(&array);
+    testing.expectEqual(expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard resistor-color-duo practice exercise.
- Also fixes a problem between the resistor-color and resistor-color-duo entries in the track's config.json file. They were added incorrectly in different pull requests. This pull request will add resistor-color into the track's config.json file and alter the existing resistor-color-duo to actually match the specifications of the implemented exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.