### PR TITLE
Add darts practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -154,6 +154,26 @@
           "functions"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "3819c81e-db22-4aac-b745-5eec450b7b4d",
+        "slug": "darts",
+        "name": "Darts",
+        "practices": [
+          "conditionals",
+          "functions",
+          "importing",
+          "methods",
+          "structs"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "functions",
+          "importing",
+          "methods",
+          "structs"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/darts/.docs/instructions.md
+++ b/exercises/practice/darts/.docs/instructions.md
@@ -1,0 +1,17 @@
+# Description
+
+Write a function that returns the earned points in a single toss of a Darts game.
+
+[Darts](https://en.wikipedia.org/wiki/Darts) is a game where players
+throw darts to a [target](https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg).
+
+In our particular instance of the game, the target rewards with 4 different amounts of points, depending on where the dart lands:
+
+* If the dart lands outside the target, player earns no points (0 points).
+* If the dart lands in the outer circle of the target, player earns 1 point.
+* If the dart lands in the middle circle of the target, player earns 5 points.
+* If the dart lands in the inner circle of the target, player earns 10 points.
+
+The outer circle has a radius of 10 units (This is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered to the same point (That is, the circles are [concentric](http://mathworld.wolfram.com/ConcentricCircles.html)) defined by the coordinates (0, 0).
+
+Write a function that given a point in the target (defined by its `real` cartesian coordinates `x` and `y`), returns the correct amount earned by a dart landing in that point.

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,0 +1,21 @@
+{
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "darts.zig"
+    ],
+    "test": [
+      "test_darts.zig"
+    ]
+  },
+  "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
+}

--- a/exercises/practice/darts/.meta/example.zig
+++ b/exercises/practice/darts/.meta/example.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const math = std.math;
+
+pub const Coordinate = struct {
+    x_coord: f32,
+    y_coord: f32,
+
+    pub fn init(x_coord: f32, y_coord: f32) Coordinate {
+        return Coordinate {
+            .x_coord = x_coord,
+            .y_coord = y_coord,
+        };
+    }
+
+    pub fn score(self: Coordinate) isize {
+        var d = math.sqrt(self.x_coord * self.x_coord +
+            self.y_coord * self.y_coord);
+        if (d > 10) {
+            return 0;
+        } else if (d > 5) {
+            return 1;
+        } else if (d > 1) {
+            return 5;
+        }
+        return 10;
+    }
+};

--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -1,0 +1,55 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
+description = "Missed target"
+include = true
+
+[4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
+description = "On the outer circle"
+include = true
+
+[14378687-ee58-4c9b-a323-b089d5274be8]
+description = "On the middle circle"
+include = true
+
+[849e2e63-85bd-4fed-bc3b-781ae962e2c9]
+description = "On the inner circle"
+include = true
+
+[1c5ffd9f-ea66-462f-9f06-a1303de5a226]
+description = "Exactly on centre"
+include = true
+
+[b65abce3-a679-4550-8115-4b74bda06088]
+description = "Near the centre"
+include = true
+
+[66c29c1d-44f5-40cf-9927-e09a1305b399]
+description = "Just within the inner circle"
+include = true
+
+[d1012f63-c97c-4394-b944-7beb3d0b141a]
+description = "Just outside the inner circle"
+include = true
+
+[ab2b5666-b0b4-49c3-9b27-205e790ed945]
+description = "Just within the middle circle"
+include = true
+
+[70f1424e-d690-4860-8caf-9740a52c0161]
+description = "Just outside the middle circle"
+include = true
+
+[a7dbf8db-419c-4712-8a7f-67602b69b293]
+description = "Just within the outer circle"
+include = true
+
+[e0f39315-9f9a-4546-96e4-a9475b885aa7]
+description = "Just outside the outer circle"
+include = true
+
+[045d7d18-d863-4229-818e-b50828c75d19]
+description = "Asymmetric position between the inner and middle circles"
+include = true

--- a/exercises/practice/darts/darts.zig
+++ b/exercises/practice/darts/darts.zig
@@ -1,0 +1,10 @@
+pub const Coordinate = struct {
+    // This struct, as well as it's fields and methods, needs to be implemented.
+    
+    pub fn init(x_coord: f32, y_coord: f32) Coordinate {
+        @panic("please implement the init method");
+    }
+    pub fn score(self: Coordinate) isize {
+        @panic("please implement the score method");
+    }
+};

--- a/exercises/practice/darts/test_darts.zig
+++ b/exercises/practice/darts/test_darts.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const testing = std.testing;
+
+const darts = @import("darts.zig");
+
+test "missed target" {
+    const coordinate = comptime darts.Coordinate.init(-9.0, 9.0);
+    const expected = 0;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "on the outer circle" {
+    const coordinate = comptime darts.Coordinate.init(0.0, 10.0);
+    const expected = 1;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "on the middle circle" {
+    const coordinate = comptime darts.Coordinate.init(-5.0, 0.0);
+    const expected = 5;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "on the inner circle" {
+    const coordinate = comptime darts.Coordinate.init(0.0, -1.0);
+    const expected = 10;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "exactly on center" {
+    const coordinate = comptime darts.Coordinate.init(0.0, 0.0);
+    const expected = 10;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "near the center" {
+    const coordinate = comptime darts.Coordinate.init(-0.1, -0.1);
+    const expected = 10;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "just within the inner circle" {
+    const coordinate = comptime darts.Coordinate.init(0.7, 0.7);
+    const expected = 10;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "just outside the inner circle" {
+    const coordinate = comptime darts.Coordinate.init(0.8, -0.8);
+    const expected = 5;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "just within the middle circle" {
+    const coordinate = comptime darts.Coordinate.init(3.5, -3.5);
+    const expected = 5;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "just outside the middle circle" {
+    const coordinate = comptime darts.Coordinate.init(-3.6, -3.6);
+    const expected = 1;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "just within the outer circle" {
+    const coordinate = comptime darts.Coordinate.init(-7.0, 7.0);
+    const expected = 1;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "just outside the outer circle" {
+    const coordinate = comptime darts.Coordinate.init(7.1, -7.1);
+    const expected = 0;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}
+
+test "asymmetric position between the inner and middle circles" {
+    const coordinate = comptime darts.Coordinate.init(0.5, -4.0);
+    const expected = 5;
+    const actual = comptime coordinate.score();
+    comptime testing.expectEqual(expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard darts practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.