### PR TITLE
Add hamming practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -174,6 +174,26 @@
           "structs"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "bd72bb30-583f-494c-818d-4394703293a1",
+        "slug": "hamming",
+        "name": "Hamming",
+        "topics": [
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "functions",
+          "slices"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "functions",
+          "slices"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -179,19 +179,21 @@
         "uuid": "bd72bb30-583f-494c-818d-4394703293a1",
         "slug": "hamming",
         "name": "Hamming",
-        "topics": [
+        "practices": [
           "conditionals",
           "control-flow",
           "error-sets",
           "functions",
-          "slices"
+          "slices",
+          "type-coercion"
         ],
         "prerequisites": [
           "conditionals",
           "control-flow",
           "error-sets",
           "functions",
-          "slices"
+          "slices",
+          "type-coercion"
         ],
         "difficulty": 1
       }

--- a/exercises/practice/hamming/.docs/instructions.md
+++ b/exercises/practice/hamming/.docs/instructions.md
@@ -1,0 +1,23 @@
+# Description
+
+Calculate the Hamming Distance between two DNA strands.
+
+Your body is made up of cells that contain DNA. Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells. In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
+
+When cells divide, their DNA replicates too. Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information. If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred. This is known as the "Hamming Distance".
+
+We read DNA using the letters C,A,G and T. Two strands might look like this:
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+They have 7 differences, and therefore the Hamming Distance is 7.
+
+The Hamming Distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length, so
+an attempt to calculate it between sequences of different lengths should
+not work.

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "hamming.zig"
+    ],
+    "test": [
+      "test_hamming.zig"
+    ]
+  },
+  "source": "The Calculating Point Mutations problem at Rosalind",
+  "source_url": "http://rosalind.info/problems/hamm/"
+}

--- a/exercises/practice/hamming/.meta/example.zig
+++ b/exercises/practice/hamming/.meta/example.zig
@@ -1,0 +1,23 @@
+pub const DNAError = error {
+    EmptyDNAStrands,
+    UnequalDNAStrands,
+};
+
+pub fn compute(
+    first: []const u8,
+    second: []const u8
+) DNAError!usize {
+    if (first.len == 0 or second.len == 0) {
+        return DNAError.EmptyDNAStrands;
+    }
+    if (first.len != second.len) {
+        return DNAError.UnequalDNAStrands;
+    }
+    var hamming_distance: usize = 0;
+    for (first) |rune, i| {
+        if (rune != second[i]) {
+            hamming_distance += 1;
+        }
+    }
+    return hamming_distance;
+}

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,63 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+include = true
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+include = true
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+include = true
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+include = true
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+include = true
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+include = true
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+include = true
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+include = true
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+include = false
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+include = true
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+include = false
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+include = false
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+include = true
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow empty second strand"
+include = false
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+include = false

--- a/exercises/practice/hamming/hamming.zig
+++ b/exercises/practice/hamming/hamming.zig
@@ -1,0 +1,6 @@
+pub fn compute(
+    first: []const u8,
+    second: []const u8
+) DNAError!usize {
+    @panic("please implement the compute function");
+}

--- a/exercises/practice/hamming/test_hamming.zig
+++ b/exercises/practice/hamming/test_hamming.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const testing = std.testing;
+
+const hamming = @import("hamming.zig");
+const DNAError = hamming.DNAError;
+
+test "empty strands" {
+    const expected = DNAError.EmptyDNAStrands;
+    const actual = comptime hamming.compute("", "");
+    testing.expectError(expected, actual);
+}
+
+test "single letter identical strands" {
+    const expected = 0;
+    const actual = comptime try hamming.compute("A", "A");
+    testing.expectEqual(expected, actual);
+}
+
+test "single letter different strands" {
+    const expected = 1;
+    const actual = comptime try hamming.compute("G", "T");
+    testing.expectEqual(expected, actual);
+}
+
+test "long identical strands" {
+    const expected = 0;
+    const actual = comptime try hamming
+        .compute("GGACTGAAATCTG", "GGACTGAAATCTG");
+    testing.expectEqual(expected, actual);
+}
+
+test "long different strands" {
+    const expected = 9;
+    const actual = comptime try hamming
+        .compute("GGACGGATTCTG", "AGGACGGATTCT");
+    testing.expectEqual(expected, actual);
+}
+
+test "disallow first strand longer" {
+    const expected = DNAError.UnequalDNAStrands;
+    const actual = comptime hamming.compute("AATG", "AAA");
+    testing.expectError(expected, actual);
+}
+
+test "disallow second strand longer" {
+    const expected = DNAError.UnequalDNAStrands;
+    const actual = comptime hamming.compute("ATA", "AGTG");
+    testing.expectError(expected, actual);
+}
+
+test "disallow left empty strand" {
+    const expected = DNAError.EmptyDNAStrands;
+    const actual = comptime hamming.compute("", "G");
+    testing.expectError(expected, actual);
+}
+
+test "disallow right empty strand" {
+    const expected = DNAError.EmptyDNAStrands;
+    const actual = comptime hamming.compute("G", "");
+    testing.expectError(expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard hamming practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.