### PR TITLE
Add leap practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -196,6 +196,20 @@
           "type-coercion"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "5e8e92f6-e8c7-49f1-8ebf-a93f73998d47",
+        "slug": "leap",
+        "name": "Leap",
+        "practices": [
+          "conditionals",
+          "functions"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "functions"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/leap/.docs/instructions.md
+++ b/exercises/practice/leap/.docs/instructions.md
@@ -1,0 +1,24 @@
+# Description
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```text
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "blurb": "Given a year, report if it is a leap year.",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "leap.zig"
+    ],
+    "test": [
+      "test_leap.zig"
+    ]
+  },
+  "source": "JavaRanch Cattle Drive, exercise 3",
+  "source_url": "http://www.javaranch.com/leap.jsp"
+}

--- a/exercises/practice/leap/.meta/example.zig
+++ b/exercises/practice/leap/.meta/example.zig
@@ -1,0 +1,11 @@
+pub fn leap(year: u32) bool {
+    const has_factor = (struct {
+        const Self = @This();
+        y: u32,
+        fn has_factor(self: Self, factor: u32) bool {
+            return self.y % factor == 0;
+        }
+    }{ .y = year }).has_factor;
+
+    return has_factor(4) and (!has_factor(100) or has_factor(400));
+}

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,39 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+include = true
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+include = true
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+include = true
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+include = true
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+include = true
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap yea"r
+include = true
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 in leap year"
+include = true
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+include = true
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"
+include = true

--- a/exercises/practice/leap/leap.zig
+++ b/exercises/practice/leap/leap.zig
@@ -1,0 +1,3 @@
+pub fn leap(year: u32) bool {
+    @panic("please implement the leap function");
+}

--- a/exercises/practice/leap/test_leap.zig
+++ b/exercises/practice/leap/test_leap.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const testing = std.testing;
+
+const leap = @import("leap.zig");
+
+test "year not divisible by 4 in common year" {
+    comptime testing.expect(!leap.leap(2015));
+}
+
+test "year divisible by 2, not divisible by 4 in common year" {
+    comptime testing.expect(!leap.leap(1970));
+}
+
+test "year divisible by 4, not divisible by 100 in leap year" {
+    comptime testing.expect(leap.leap(1996));
+}
+
+test "year divisible by 4 and 5 is still a leap year" {
+    comptime testing.expect(leap.leap(1960));
+}
+
+test "year divisible by 100, not divisible by 400 in common year" {
+    comptime testing.expect(!leap.leap(2100));
+}
+
+test "year divisible by 100 but not by 3 is still not a leap year" {
+    comptime testing.expect(!leap.leap(1900));
+}
+
+test "year divisible by 400 is leap year" {
+    comptime testing.expect(leap.leap(2000));
+}
+
+test "year divisible by 400 but not by 125 is still a leap year" {
+    comptime testing.expect(leap.leap(2400));
+}
+
+test "year divisible by 200, not divisible by 400 in common year" {
+    comptime testing.expect(!leap.leap(1800));
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard leap practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.