### PR TITLE
Add triangle practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -210,6 +210,28 @@
           "functions"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "d36abb68-78cc-4c99-8693-00e02eb9011e",
+        "slug": "triangle",
+        "name": "Triangle",
+        "practices": [
+          "bitwise-operations",
+          "conditionals",
+          "error-sets",
+          "functions",
+          "methods",
+          "structs"
+        ],
+        "prerequisites": [
+          "bitwise-operations",
+          "conditionals",
+          "error-sets",
+          "functions",
+          "methods",
+          "structs"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -1,0 +1,23 @@
+# Description
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.
+
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)
+
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and
+the sum of the lengths of any two sides must be greater than or equal to the
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the
+third is known as a _degenerate_ triangle - it has zero area and looks like
+a single line. Feel free to add your own code/tests to check for degenerate triangles.

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "triangle.zig"
+    ],
+    "test": [
+      "test_triangle.zig"
+    ]
+  },
+  "source": "The Ruby Koans triangle project, parts 1 & 2",
+  "source_url": "http://rubykoans.com"
+}

--- a/exercises/practice/triangle/.meta/example.zig
+++ b/exercises/practice/triangle/.meta/example.zig
@@ -1,0 +1,66 @@
+pub const TriangleError = error {
+    Degenerate,
+    InvalidInequality,
+};
+
+pub const Triangle = struct {
+    first: f64,
+    second: f64,
+    third: f64,
+
+    pub fn init(
+        first: f64,
+        second: f64,
+        third: f64
+    ) TriangleError!Triangle {
+        try verifyIfDegenerateAttributesExist(first, second, third);
+        try verifyIfTriangleInequalityHolds(first, second, third);
+        return Triangle {
+            .first = first,
+            .second = second,
+            .third = third,
+        };
+    }
+
+    fn verifyIfDegenerateAttributesExist(
+        first: f64,
+        second: f64,
+        third: f64
+    ) TriangleError!void {
+        if ((first + second == third) or
+            (first + third == second) or
+            (second + third == first)) {
+            return TriangleError.Degenerate;
+        }
+    }
+
+    fn verifyIfTriangleInequalityHolds(
+        first: f64,
+        second: f64,
+        third: f64
+    ) TriangleError!void {
+        if ((first + second < third) or
+            (first + third < second) or
+            (second + third < first)) {
+            return TriangleError.InvalidInequality;
+        }
+    }
+
+    pub fn isEquilateral(self: Triangle) bool {
+        return (self.first == self.second) and 
+               (self.second == self.third) and
+               (self.first == self.third);
+    }
+
+    pub fn isIsosceles(self: Triangle) bool {
+        return (self.first == self.second) or
+               (self.second == self.third) or
+               (self.first == self.third);
+    }
+
+    pub fn isScalene(self: Triangle) bool {
+        return (self.first != self.second) and
+               (self.second != self.third) and
+               (self.first != self.third);
+    }
+};

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,0 +1,79 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "all sides are equal"
+include = true
+
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "any side is unequal"
+include = true
+
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "no sides are equal"
+include = true
+
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "all zero sides is not a triangle"
+include = true
+
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "sides may be floats"
+include = true
+
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "last two sides are equal"
+include = true
+
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "first two sides are equal"
+include = true
+
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "first and last sides are equal"
+include = true
+
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "equilateral triangles are also isosceles"
+include = true
+
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "no sides are equal"
+include = true
+
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "first triangle inequality violation"
+include = true
+
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "second triangle inequality violation"
+include = true
+
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "third triangle inequality violation"
+include = true
+
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "sides may be floats"
+include = true
+
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "no sides are equal"
+include = true
+
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "all sides are equal"
+include = true
+
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "two sides are equal"
+include = true
+
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "may not violate triangle inequality"
+include = true
+
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "sides may be floats"
+include = true

--- a/exercises/practice/triangle/test_triangle.zig
+++ b/exercises/practice/triangle/test_triangle.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const testing = std.testing;
+
+const triangle = @import("triangle.zig");
+
+test "equilateral all sides are equal" {
+    const actual = comptime try triangle.Triangle.init(2, 2, 2);
+    comptime testing.expect(actual.isEquilateral());
+}
+
+test "equilateral any side is unequal" {
+    const actual = comptime try triangle.Triangle.init(2, 3, 2);
+    comptime testing.expect(!actual.isEquilateral());
+}
+
+test "equilateral no sides are equal" {
+    const actual = comptime try triangle.Triangle.init(5, 4, 6);
+    comptime testing.expect(!actual.isEquilateral());
+}
+
+test "equilateral all zero sies is not a triangle" {
+    const actual = triangle.Triangle.init(0, 0, 0);
+    testing.expectError(triangle.TriangleError.Degenerate, actual);
+}
+
+test "equilateral sides may be floats" {
+    const actual = comptime try triangle.Triangle.init(0.5, 0.5, 0.5);
+    comptime testing.expect(actual.isEquilateral());
+}
+
+test "isosceles last two sides are equal" {
+    const actual = comptime try triangle.Triangle.init(3, 4, 4);
+    comptime testing.expect(actual.isIsosceles());
+}
+
+test "isosceles first two sides are equal" {
+    const actual = comptime try triangle.Triangle.init(4, 4, 3);
+    comptime testing.expect(actual.isIsosceles());
+}
+
+test "isosceles first and last sides are equal" {
+    const actual = comptime try triangle.Triangle.init(4, 3, 4);
+    comptime testing.expect(actual.isIsosceles());
+}
+
+test "equilateral triangles are also isosceles" {
+    const actual = comptime try triangle.Triangle.init(4, 3, 4);
+    comptime testing.expect(actual.isIsosceles());
+}
+
+test "isosceles no sides are equal" {
+    const actual = comptime try triangle.Triangle.init(2, 3, 4);
+    comptime testing.expect(!actual.isIsosceles());
+}
+
+test "isosceles first triangle inequality violation" {
+    const actual = triangle.Triangle.init(1, 1, 3);
+    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+}
+
+test "isosceles second triangle inequality violation" {
+    const actual = triangle.Triangle.init(1, 3, 1);
+    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+}
+
+test "isosceles third triangle inequality violation" {
+    const actual = triangle.Triangle.init(3, 1, 1);
+    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+}
+
+test "isosceles sides may be floats" {
+    const actual = comptime try triangle.Triangle.init(0.5, 0.4, 0.5);
+    comptime testing.expect(actual.isIsosceles());
+}
+
+test "scalene no sides are equal" {
+    const actual = comptime try triangle.Triangle.init(5, 4, 6);
+    comptime testing.expect(actual.isScalene());
+}
+
+test "scalene all sides are equal" {
+    const actual = comptime try triangle.Triangle.init(4, 4, 4);
+    comptime testing.expect(!actual.isScalene());
+}
+
+test "scalene two sides are equal" {
+    const actual = comptime try triangle.Triangle.init(4, 4, 3);
+    comptime testing.expect(!actual.isScalene());
+}
+
+test "scalene two sides are equal" {
+    const actual = comptime try triangle.Triangle.init(4, 4, 3);
+    comptime testing.expect(!actual.isScalene());
+}
+
+test "scalene may not violate triangle inequality" {
+    const actual = triangle.Triangle.init(7, 3, 2);
+    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+}
+
+test "scalene sides may be floats" {
+    const actual = comptime try triangle.Triangle.init(0.5, 0.4, 0.6);
+    comptime testing.expect(actual.isScalene());
+}

--- a/exercises/practice/triangle/triangle.zig
+++ b/exercises/practice/triangle/triangle.zig
@@ -1,0 +1,39 @@
+pub const Triangle = struct {
+    // This struct, as well as it's fields and methods, needs to be implemented.
+
+    pub fn init(
+        first: f64,
+        second: f64,
+        third: f64
+    ) TriangleError!Triangle {
+        @panic("please implement the init method");
+    }
+
+    fn verifyIfDegenerateAttributesExist(
+        first: f64,
+        second: f64,
+        third: f64
+    ) TriangleError!void {
+        @panic("optional verifyIfDegenerateAttributesExist method");
+    }
+
+    fn verifyIfTriangleInequalityHolds(
+        first: f64,
+        second: f64,
+        third: f64
+    ) TriangleError!void {
+        @panic("please implement the verifyIfTriangleInequalityHolds method");
+    }
+
+    pub fn isEquilateral(self: Triangle) bool {
+        @panic("please implement the isEquilateral method");
+    }
+
+    pub fn isIsosceles(self: Triangle) bool {
+        @panic("please implement the isIsosceles method");
+    }
+
+    pub fn isScalene(self: Triangle) bool {
+        @panic("please implement the isScalene method");
+    }
+};


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard triangle practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.