### PR TITLE
Add pangram practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -232,6 +232,30 @@
           "structs"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "8f48a213-9a28-4a7e-93f9-f2b1fbe46e58",
+        "slug": "pangram",
+        "name": "Pangram",
+        "topics": [
+          "bitwise-operations",
+          "builtin-functions",
+          "conditionals",
+          "control-flow",
+          "importing",
+          "slices",
+          "type-coercion"
+        ],
+        "prerequisites": [
+          "bitwise-operations",
+          "builtin-functions",
+          "conditionals",
+          "control-flow",
+          "importing",
+          "slices",
+          "type-coercion"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -1,0 +1,9 @@
+# Description
+
+Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
+"every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is:
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Input will not contain non-ASCII symbols.

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "blurb": "Determine if a sentence is a pangram.",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "pangram.zig"
+    ],
+    "test": [
+      "test_pangram.zig"
+    ]
+  },
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Pangram"
+}

--- a/exercises/practice/pangram/.meta/example.zig
+++ b/exercises/practice/pangram/.meta/example.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const ascii = std.ascii;
+
+pub fn isPangram(str: []const u8) bool {
+    if (str.len < 26) {
+        return false;
+    }
+    var ascii_bit_set: u32 = 0;
+    for (str) |c| {
+        if (ascii.isASCII(c) and ascii.isAlpha(c)) {
+            ascii_bit_set |= @as(u32, 1) <<
+                @truncate(u5, ascii.toLower(c) - 'a');
+        }
+    }
+    return ascii_bit_set == 0x03ffffff;
+}

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+include = true
+
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+include = true
+
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+include = true
+
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+include = true
+
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+include = true
+
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+include = true
+
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+include = true
+
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+include = true
+
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+include = true
+
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"
+include = true

--- a/exercises/practice/pangram/pangram.zig
+++ b/exercises/practice/pangram/pangram.zig
@@ -1,0 +1,3 @@
+pub fn isPangram(str: []const u8) bool {
+    @panic("please implement the isPangram function");
+}

--- a/exercises/practice/pangram/test_pangram.zig
+++ b/exercises/practice/pangram/test_pangram.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const testing = std.testing;
+
+const pangram = @import("pangram.zig");
+
+test "empty sentence" {
+    comptime testing.expect(!pangram.isPangram(""));
+}
+
+test "perfect lower case" {
+    comptime testing.expect(
+        pangram.isPangram("abcdefghijklmnopqrstuvwxyz"));
+}
+
+test "only lower case" {
+    comptime testing.expect(pangram.isPangram(
+        "the quick brown fox jumps over the lazy dog"));
+}
+
+test "missing letter x" {
+    comptime testing.expect(!pangram.isPangram(
+        "a quick movement of the enemy will jeopardize five gunboats"));
+}
+
+test "missing letter h" {
+    comptime testing.expect(!pangram.isPangram(
+        "five boxing wizards jump quickly at it"));
+}
+
+test "with underscores" {
+    comptime testing.expect(pangram.isPangram(
+        "the_quick_brown_fox_jumps_over_the_lazy_dog"));
+}
+
+test "with numbers" {
+    comptime testing.expect(pangram.isPangram(
+        "the 1 quick brown fox jumps over the 2 lazy dogs"));
+}
+
+test "missing letters replaced by numbers" {
+    comptime testing.expect(!pangram.isPangram(
+        "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"));
+}
+
+test "missing letters replaced by numbers" {
+    comptime testing.expect(pangram.isPangram(
+        "\"Five quacking Zephyrs jolt my wax bed.\""));
+}
+
+test "case insensitive" {
+    comptime testing.expect(!pangram.isPangram(
+        "the quick brown fox jumps over with lazy FX"));
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard pangram practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.