### PR TITLE
Add rna-transcription practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -256,6 +256,28 @@
           "type-coercion"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "9f715841-e4d0-491e-9ed7-af36c8eafb49",
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "practices": [
+          "allocators",
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "slices",
+          "type-coercion"
+        ],
+        "prerequisites": [
+          "allocators",
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "slices",
+          "type-coercion"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/rna-transcription/.docs/instructions.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.md
@@ -1,0 +1,19 @@
+# Description
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,0 +1,23 @@
+{
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "rna_transcription.zig"
+    ],
+    "test": [
+      "test_rna_transcription.zig"
+    ]
+  },
+  "source": "Hyperphysics",
+  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
+  "title": "RNA Transcription"
+}

--- a/exercises/practice/rna-transcription/.meta/example.zig
+++ b/exercises/practice/rna-transcription/.meta/example.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const mem = std.mem;
+
+pub const RNAError = error {
+    IllegalDNANucleotide,
+};
+
+pub fn toRna(
+    allocator: *mem.Allocator,
+    dna: []const u8
+) (RNAError || mem.Allocator.Error)![]const u8 {
+    var rna_slice = try allocator.alloc(u8, dna.len);
+    for (dna) |dna_nucleotide, i| {
+        switch (dna_nucleotide) {
+            'A' => rna_slice[i] = 'U',
+            'C' => rna_slice[i] = 'G',
+            'G' => rna_slice[i] = 'C',
+            'T' => rna_slice[i] = 'A',
+            else => {
+                allocator.free(rna_slice);
+                return RNAError.IllegalDNANucleotide;
+            },
+        }
+    }
+    return rna_slice;
+}

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,27 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+include = true
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+include = true
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+include = true
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+include = true
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+include = true
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"
+include = true

--- a/exercises/practice/rna-transcription/rna_transcription.zig
+++ b/exercises/practice/rna-transcription/rna_transcription.zig
@@ -1,0 +1,8 @@
+// Import the appropriate standard library and modules
+
+pub fn toRna(
+    allocator: *mem.Allocator,
+    dna: []const u8
+) (RNAError || mem.Allocator.Error)![]const u8 {
+    @panic("please implement the toRna function");
+}

--- a/exercises/practice/rna-transcription/test_rna_transcription.zig
+++ b/exercises/practice/rna-transcription/test_rna_transcription.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const mem = std.mem;
+const testing = std.testing;
+
+const rna_transcription = @import("rna_transcription.zig");
+const RNAError = rna_transcription.RNAError;
+
+fn test_transcription(
+    dna: []const u8,
+    expected: []const u8
+) (rna_transcription.RNAError || mem.Allocator.Error)!void {
+    const rna = try rna_transcription.toRna(testing.allocator, dna);
+    testing.expectEqualStrings(expected, rna);
+    testing.allocator.free(rna);
+}
+
+fn test_failure(
+    dna: []const u8
+) (rna_transcription.RNAError || mem.Allocator.Error)!void {
+    const expected = RNAError.IllegalDNANucleotide;
+    const actual = rna_transcription.toRna(testing.allocator, dna);
+    testing.expectError(expected, actual);
+}
+
+
+test "empty rna sequence" {
+    try test_transcription("", "");
+}
+
+test "rna complement of cytosine is guanine" {
+    try test_transcription("C", "G");
+}
+
+test "rna complement of guanine is cytosine" {
+    try test_transcription("G", "C");
+}
+
+test "rna complement of thymine is adenine" {
+    try test_transcription("T", "A");
+}
+
+test "rna complement of adenine is uracil" {
+    try test_transcription("A", "U");
+}
+
+test "rna complement" {
+    try test_transcription("ACGTGGTCTTAA", "UGCACCAGAAUU");
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard rna-transcription practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.