### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "2c70b6e2-6262-45ee-9a15-cacdcce1b9ed",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Zig locally",
+      "blurb": "Learn how to install Zig locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "77b5dbb7-0afe-406e-9ecf-ccf34c255092",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Zig",
+      "blurb": "An overview of how to get started from scratch with Zig"
+    },
+    {
+      "uuid": "10443c51-6e89-4825-b152-435ef1aecfe6",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Zig track",
+      "blurb": "Learn how to test your Zig exercises on Exercism"
+    },
+    {
+      "uuid": "11236326-4195-4410-b1c2-97ef80ddbbe6",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Zig resources",
+      "blurb": "A collection of useful resources to help you master Zig"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
