### PR TITLE
Add space-age practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -276,6 +276,28 @@
           "type-coercion"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "280bd414-898d-4ab9-8a7c-f9c0d1e382f6",
+        "slug": "space-age",
+        "name": "Space Age",
+        "practices": [
+          "builtin-functions",
+          "control-flow",
+          "enums",
+          "functions",
+          "methods",
+          "structs"
+        ],
+        "prerequisites": [
+          "builtin-functions",
+          "control-flow",
+          "enums",
+          "functions",
+          "methods",
+          "structs"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/space-age/.docs/instructions.md
+++ b/exercises/practice/space-age/.docs/instructions.md
@@ -1,0 +1,18 @@
+# Description
+
+Given an age in seconds, calculate how old someone would be on:
+
+   - Mercury: orbital period 0.2408467 Earth years
+   - Venus: orbital period 0.61519726 Earth years
+   - Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
+   - Mars: orbital period 1.8808158 Earth years
+   - Jupiter: orbital period 11.862615 Earth years
+   - Saturn: orbital period 29.447498 Earth years
+   - Uranus: orbital period 84.016846 Earth years
+   - Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31.69 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this
+youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "space_age.zig"
+    ],
+    "test": [
+      "test_space_age.zig"
+    ]
+  },
+  "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"
+}

--- a/exercises/practice/space-age/.meta/example.zig
+++ b/exercises/practice/space-age/.meta/example.zig
@@ -1,0 +1,80 @@
+pub const Planet = enum(u4) {
+    mercury,
+    venus,
+    earth,
+    mars,
+    jupiter,
+    saturn,
+    uranus,
+    neptune,
+};
+
+pub const SpaceAge = struct {
+    seconds: f64,
+
+    const EARTH_YEAR_IN_SECONDS = 31557600;
+
+    pub fn init(seconds: isize) SpaceAge {
+        return SpaceAge {
+            .seconds = @intToFloat(f64, seconds),
+        };
+    }
+
+    fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
+        return EARTH_YEAR_IN_SECONDS *
+            getOrbitalPeriodInEarthYearsOf(planet);
+    }
+
+    fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
+        return switch (planet) {
+            .mercury => 0.2408467,
+            .venus   => 0.61419726,
+            .earth   => 1.0,
+            .mars    => 1.8808158,
+            .jupiter => 11.862615,
+            .saturn  => 29.447498,
+            .uranus  => 84.016846,
+            .neptune => 164.79132,
+        };
+    }
+
+    pub fn onMercury(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.mercury);
+    }
+
+    pub fn onVenus(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.venus);
+    }
+
+    pub fn onEarth(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.earth);
+    }
+
+    pub fn onMars(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.mars);
+    }
+
+    pub fn onJupiter(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.jupiter);
+    }
+
+    pub fn onSaturn(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.saturn);
+    }
+
+    pub fn onUranus(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.uranus);
+    }
+
+    pub fn onNeptune(self: SpaceAge) f64 {
+        return self.seconds /
+            getOrbitalPeriodInSecondsFromEarthYearsOf(.neptune);
+    }
+};

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,0 +1,35 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
+include = true
+
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
+include = true
+
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
+include = true
+
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
+include = true
+
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
+include = true
+
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
+include = true
+
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
+include = true
+
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"
+include = true

--- a/exercises/practice/space-age/space_age.zig
+++ b/exercises/practice/space-age/space_age.zig
@@ -1,0 +1,52 @@
+// An enum should be helpful for this exercise.
+
+pub const SpaceAge = struct {
+    // This struct, as well as it's fields and methods, needs to be
+    // implemented.
+
+    pub fn init(seconds: isize) SpaceAge {
+        @panic("please implement the init method");
+    }
+
+    fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
+        @panic("please implement the
+            getOrbitalPeriodInSecondsFromEarthYearsOf method");
+    }
+
+    fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
+        @panic("please implement the
+            getOrbitalPeriodInEarthYearsOf method");
+    }
+
+    pub fn onMercury(self: SpaceAge) f64 {
+        @panic("please implement the onMercury method");
+    }
+
+    pub fn onVenus(self: SpaceAge) f64 {
+        @panic("please implement the onVenus method");
+    }
+
+    pub fn onEarth(self: SpaceAge) f64 {
+        @panic("please implement the onEarth method");
+    }
+
+    pub fn onMars(self: SpaceAge) f64 {
+        @panic("please implement the onMars method");
+    }
+
+    pub fn onJupiter(self: SpaceAge) f64 {
+        @panic("please implement the onJupiter method");
+    }
+
+    pub fn onSaturn(self: SpaceAge) f64 {
+        @panic("please implement the onSaturn method");
+    }
+
+    pub fn onUranus(self: SpaceAge) f64 {
+        @panic("please implement the onUranus method");
+    }
+
+    pub fn onNeptune(self: SpaceAge) f64 {
+        @panic("please implement the onNeptune method");
+    }
+};

--- a/exercises/practice/space-age/test_space_age.zig
+++ b/exercises/practice/space-age/test_space_age.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const testing = std.testing;
+
+const space_age = @import("space_age.zig");
+
+test "age on earth" {
+    const sp = comptime space_age.SpaceAge.init(1000000000);
+    const expected = 31.69;
+    const actual = comptime sp.onEarth();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on mercury" {
+    const sp = comptime space_age.SpaceAge.init(2134835688);
+    const expected = 280.88;
+    const actual = comptime sp.onMercury();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on venus" {
+    const sp = comptime space_age.SpaceAge.init(189839836);
+    const expected = 9.78;
+    const actual = comptime sp.onVenus();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on mars" {
+    const sp = comptime space_age.SpaceAge.init(2129871239);
+    const expected = 35.88;
+    const actual = comptime sp.onMars();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on jupiter" {
+    const sp = comptime space_age.SpaceAge.init(901876382);
+    const expected = 2.41;
+    const actual = comptime sp.onJupiter();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on saturn" {
+    const sp = comptime space_age.SpaceAge.init(2000000000);
+    const expected = 2.15;
+    const actual = comptime sp.onSaturn();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on uranus" {
+    const sp = comptime space_age.SpaceAge.init(1210123456);
+    const expected = 0.46;
+    const actual = comptime sp.onUranus();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}
+
+test "age on neptune" {
+    const sp = comptime space_age.SpaceAge.init(1821023456);
+    const expected = 0.35;
+    const actual = comptime sp.onNeptune();
+    comptime testing.expectWithinMargin(expected, actual, 1.0);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard space-age practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.