### PR TITLE
Add queen-attack practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -298,6 +298,26 @@
           "structs"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "6eb542c3-c14f-430a-81ce-ba9f2c0551c2",
+        "slug": "queen-attack",
+        "name": "Queen Attack",
+        "practices": [
+          "control-flow",
+          "error-sets",
+          "importing",
+          "methods",
+          "structs"
+        ],
+        "prerequisites": [
+          "control-flow",
+          "error-sets",
+          "importing",
+          "methods",
+          "structs"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/queen-attack/.docs/instructions.md
+++ b/exercises/practice/queen-attack/.docs/instructions.md
@@ -1,0 +1,27 @@
+# Description
+
+Given the position of two queens on a chess board, indicate whether or not they
+are positioned so that they can attack each other.
+
+In the game of chess, a queen can attack pieces which are on the same
+row, column, or diagonal.
+
+A chessboard can be represented by an 8 by 8 array.
+
+So if you're told the white queen is at (2, 3) and the black queen at
+(5, 6), then you'd know you've got a set-up like so:
+
+```text
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ B _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+```
+
+You'd also be able to answer whether the queens can attack each other.
+In this case, that answer would be yes, they can, because both pieces
+share a diagonal.

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "queen_attack.zig"
+    ],
+    "test": [
+      "test_queen_attack.zig"
+    ]
+  },
+  "source": "J Dalbey's Programming Practice problems",
+  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+}

--- a/exercises/practice/queen-attack/.meta/example.zig
+++ b/exercises/practice/queen-attack/.meta/example.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+const math = std.math;
+
+pub const QueenError = error{
+    InitializationFailure,
+    InvalidAttack,
+};
+
+pub const Queen = struct {
+    x: i8,
+    y: i8,
+
+    pub fn init(x: i8, y: i8) QueenError!Queen {
+        if (x < 0 or x > 7 or y < 0 or y > 7) {
+            return QueenError.InitializationFailure;
+        }
+        return Queen {
+            .x = x,
+            .y = y,
+        };
+    }
+
+    pub fn canAttack(self: Queen, other: Queen) QueenError!bool {
+        if (self.x == other.x and self.y == other.y) {
+            return QueenError.InvalidAttack;
+        }
+        return (self.x == other.x) or (self.y == other.y) or
+            (math.absInt(self.x - other.x) catch unreachable ==
+            math.absInt(self.y - other.y) catch unreachable);
+    }
+};

--- a/exercises/practice/queen-attack/.meta/tests.toml
+++ b/exercises/practice/queen-attack/.meta/tests.toml
@@ -1,0 +1,51 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[3ac4f735-d36c-44c4-a3e2-316f79704203]
+description = "queen with a valid position"
+include = true
+
+[4e812d5d-b974-4e38-9a6b-8e0492bfa7be]
+description = "queen must have positive row"
+include = true
+
+[f07b7536-b66b-4f08-beb9-4d70d891d5c8]
+description = "queen must have row on board"
+include = true
+
+[15a10794-36d9-4907-ae6b-e5a0d4c54ebe]
+description = "queen must have positive column"
+include = true
+
+[6907762d-0e8a-4c38-87fb-12f2f65f0ce4]
+description = "queen must have column on board"
+include = true
+
+[33ae4113-d237-42ee-bac1-e1e699c0c007]
+description = "cannot attack"
+include = true
+
+[eaa65540-ea7c-4152-8c21-003c7a68c914]
+description = "can attack on same row"
+include = true
+
+[bae6f609-2c0e-4154-af71-af82b7c31cea]
+description = "can attack on same column"
+include = true
+
+[0e1b4139-b90d-4562-bd58-dfa04f1746c7]
+description = "can attack on first diagonal"
+include = true
+
+[ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd]
+description = "can attack on second diagonal"
+include = true
+
+[0a71e605-6e28-4cc2-aa47-d20a2e71037a]
+description = "can attack on third diagonal"
+include = true
+
+[0790b588-ae73-4f1f-a968-dd0b34f45f86]
+description = "can attack on fourth diagonal"
+include = true

--- a/exercises/practice/queen-attack/test_queen_attack.zig
+++ b/exercises/practice/queen-attack/test_queen_attack.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const testing = std.testing;
+
+const queen_attack = @import("queen_attack.zig");
+const QueenError = queen_attack.QueenError;
+
+test "queen with a valid position" {
+    const queen = try queen_attack.Queen.init(2, 2);
+    testing.expectEqual(
+        @as(queen_attack.Queen, .{.x = 2, .y = 2}), queen);
+}
+
+test "queen must have positive row" {
+    const queen = queen_attack.Queen.init(-2, 2);
+    testing.expectError(QueenError.InitializationFailure, queen);
+}
+
+test "queen must have row on board" {
+    const queen = queen_attack.Queen.init(8, 4);
+    testing.expectError(QueenError.InitializationFailure, queen);
+}
+
+test "queen must have positive column" {
+    const queen = queen_attack.Queen.init(2, -2);
+    testing.expectError(QueenError.InitializationFailure, queen);
+}
+
+test "queen must have column on board" {
+    const queen = queen_attack.Queen.init(4, 8);
+    testing.expectError(QueenError.InitializationFailure, queen);
+}
+
+test "cannot attack" {
+    const white = try queen_attack.Queen.init(2, 4);
+    const black = try queen_attack.Queen.init(6, 6);
+    testing.expect(!try white.canAttack(black));
+}
+
+test "can attack on same row" {
+    const white = try queen_attack.Queen.init(2, 4);
+    const black = try queen_attack.Queen.init(2, 6);
+    testing.expect(try white.canAttack(black));
+}
+
+test "can attack on same column" {
+    const white = try queen_attack.Queen.init(4, 5);
+    const black = try queen_attack.Queen.init(2, 5);
+    testing.expect(try white.canAttack(black));
+}
+
+test "can attack on first diagonal" {
+    const white = try queen_attack.Queen.init(2, 2);
+    const black = try queen_attack.Queen.init(0, 4);
+    testing.expect(try white.canAttack(black));
+}
+
+test "can attack on second diagonal" {
+    const white = try queen_attack.Queen.init(2, 2);
+    const black = try queen_attack.Queen.init(3, 1);
+    testing.expect(try white.canAttack(black));
+}
+
+test "can attack on third diagonal" {
+    const white = try queen_attack.Queen.init(2, 2);
+    const black = try queen_attack.Queen.init(1, 1);
+    testing.expect(try white.canAttack(black));
+}
+
+test "can attack on fourth diagonal" {
+    const white = try queen_attack.Queen.init(1, 7);
+    const black = try queen_attack.Queen.init(0, 6);
+    testing.expect(try white.canAttack(black));
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard queen-attack practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.