### PR TITLE
Add binary-search practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -328,14 +328,16 @@
           "error-sets",
           "generics",
           "functions",
-          "optionals"
+          "optionals",
+          "type-coercion"
         ],
         "prerequisites": [
           "control-flow",
           "error-sets",
           "generics",
           "functions",
-          "optionals"
+          "optionals",
+          "type-coercion"
         ],
         "difficulty": 1
       }

--- a/config.json
+++ b/config.json
@@ -318,6 +318,26 @@
           "structs"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "f47bbe16-dd61-4542-8634-30ea14cc4f56",
+        "slug": "binary-search",
+        "name": "Binary Search",
+        "practices": [
+          "control-flow",
+          "error-sets",
+          "generics",
+          "functions",
+          "optionals"
+        ],
+        "prerequisites": [
+          "control-flow",
+          "error-sets",
+          "generics",
+          "functions",
+          "optionals"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/binary-search/.docs/instructions.md
+++ b/exercises/practice/binary-search/.docs/instructions.md
@@ -1,0 +1,35 @@
+# Description
+
+Implement a binary search algorithm.
+
+Searching a sorted collection is a common task. A dictionary is a sorted
+list of word definitions. Given a word, one can find its definition. A
+telephone book is a sorted list of people's names, addresses, and
+telephone numbers. Knowing someone's name allows one to quickly find
+their telephone number and address.
+
+If the list to be searched contains more than a few items (a dozen, say)
+a binary search will require far fewer comparisons than a linear search,
+but it imposes the requirement that the list be sorted.
+
+In computer science, a binary search or half-interval search algorithm
+finds the position of a specified input value (the search "key") within
+an array sorted by key value.
+
+In each step, the algorithm compares the search key value with the key
+value of the middle element of the array.
+
+If the keys match, then a matching element has been found and its index,
+or position, is returned.
+
+Otherwise, if the search key is less than the middle element's key, then
+the algorithm repeats its action on the sub-array to the left of the
+middle element or, if the search key is greater, on the sub-array to the
+right.
+
+If the remaining array to be searched is empty, then the key cannot be
+found in the array and a special "not found" indication is returned.
+
+A binary search halves the number of items to check with each iteration,
+so locating an item (or determining its absence) takes logarithmic time.
+A binary search is a dichotomic divide and conquer search algorithm.

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,9 +1,6 @@
 {
   "authors": [
-    {
-      "github_username": "massivelivefun",
-      "exercism_username": "massivelivefun"
-    }
+    "massivelivefun"
   ],
   "blurb": "Implement a binary search algorithm.",
   "files": {

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    {
+      "github_username": "massivelivefun",
+      "exercism_username": "massivelivefun"
+    }
+  ],
+  "blurb": "Implement a binary search algorithm.",
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "binary_search.zig"
+    ],
+    "test": [
+      "test_binary_search.zig"
+    ]
+  },
+  "source": "Wikipedia",
+  "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"
+}

--- a/exercises/practice/binary-search/.meta/example.zig
+++ b/exercises/practice/binary-search/.meta/example.zig
@@ -1,0 +1,36 @@
+pub const SearchError = error {
+    EmptyBuffer,
+    NullBuffer,
+    ValueAbsent,
+};
+
+pub fn binarySearch(
+    comptime T: type,
+    target: T,
+    buffer: ?[]const T
+) SearchError!usize {
+    if (buffer == null) {
+        return SearchError.NullBuffer;
+    }
+    if (buffer.?.len == 0) {
+        return SearchError.EmptyBuffer;
+    }
+    var i: usize = 0;
+    var j = buffer.?.len - 1;
+    while (i < j) {
+        const mid = (i + j) >> 1;
+        if (buffer.?[mid] < target) {
+            i = mid + 1;
+        } else if (buffer.?[mid] > target) {
+            j = mid - 1;
+        } else {
+            return mid;
+        }
+    }
+    // Unroll when i == j, otherwise the function logic above might cause
+    // integer overflow to occur at the edges of usize.
+    if (buffer.?[i] == target) {
+        return j;
+    }
+    return SearchError.ValueAbsent;
+}

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -1,0 +1,47 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
+description = "finds a value in an array with one element"
+include = "true"
+
+[73469346-b0a0-4011-89bf-989e443d503d]
+description = "finds a value in the middle of an array"
+include = "true"
+
+[327bc482-ab85-424e-a724-fb4658e66ddb]
+description = "finds a value at the beginning of an array"
+include = "true"
+
+[f9f94b16-fe5e-472c-85ea-c513804c7d59]
+description = "finds a value at the end of an array"
+include = "true"
+
+[f0068905-26e3-4342-856d-ad153cadb338]
+description = "finds a value in an array of odd length"
+include = "true"
+
+[fc316b12-c8b3-4f5e-9e89-532b3389de8c]
+description = "finds a value in an array of even length"
+include = "true"
+
+[da7db20a-354f-49f7-a6a1-650a54998aa6]
+description = "identifies that a value is not included in the array"
+include = "true"
+
+[95d869ff-3daf-4c79-b622-6e805c675f97]
+description = "a value smaller than the array's smallest value is not found"
+include = "true"
+
+[8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
+description = "a value larger than the array's largest value is not found"
+include = "true"
+
+[f439a0fa-cf42-4262-8ad1-64bf41ce566a]
+description = "nothing is found in an empty array"
+include = "true"
+
+[2c353967-b56d-40b8-acff-ce43115eed64]
+description = "nothing is found when the left and right bounds cross"
+include = "true"

--- a/exercises/practice/binary-search/binary_search.zig
+++ b/exercises/practice/binary-search/binary_search.zig
@@ -1,0 +1,8 @@
+// Take a look at the tests, you might have to change the function arguments
+
+pub fn binarySearch(
+    target: usize,
+    buffer: ?[]const usize
+) SearchError!usize {
+    @panic("please implement the binarySearch function");
+}

--- a/exercises/practice/binary-search/test_binary_search.zig
+++ b/exercises/practice/binary-search/test_binary_search.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const testing = std.testing;
+
+const binary_search = @import("binary_search.zig");
+const SearchError = binary_search.SearchError;
+
+test "finds a value in an array with one element" {
+    comptime testing.expectEqual(0,
+        try binary_search.binarySearch(i4, 6,
+            &[_]i4{6}));
+}
+
+test "finds a value in the middle of an array" {
+    comptime testing.expectEqual(3,
+        try binary_search.binarySearch(u4, 6,
+            &[_]u4{1, 3, 4, 6, 8, 9, 11}));
+}
+
+test "finds a value at the beginning of an array" {
+    comptime testing.expectEqual(0,
+        try binary_search.binarySearch(i8, 1,
+            &[_]i8{1, 3, 4, 6, 8, 9, 11}));
+}
+
+test "finds a value at the end of an array" {
+    comptime testing.expectEqual(6,
+        try binary_search.binarySearch(u8, 11,
+            &[_]u8{1, 3, 4, 6, 8, 9, 11}));
+}
+
+test "finds a value in an array of odd length" {
+    comptime testing.expectEqual(5,
+        try binary_search.binarySearch(i16, 21,
+            &[_]i16{1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634}));
+}
+
+test "finds a value in an array of even length" {
+    comptime testing.expectEqual(5,
+        try binary_search.binarySearch(u16, 21,
+            &[_]u16{1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377}));
+}
+
+test "identifies that a value is not included in the array" {
+    testing.expectError(SearchError.ValueAbsent,
+        binary_search.binarySearch(i32, 7,
+            &[_]i32{1, 3, 4, 6, 8, 9, 11}));
+}
+
+test "a value smaller than the arrays smallest value is not found" {
+    testing.expectError(SearchError.ValueAbsent,
+        binary_search.binarySearch(u32, 0,
+            &[_]u32{1, 3, 4, 6, 8, 9, 11}));
+}
+
+test "a value larger than the arrays largest value is not found" {
+    testing.expectError(SearchError.ValueAbsent,
+        binary_search.binarySearch(i64, 13,
+            &[_]i64{1, 3, 4, 6, 8, 9, 11}));
+}
+
+test "nothing is found in an empty array" {
+    testing.expectError(SearchError.EmptyBuffer,
+        binary_search.binarySearch(u64, 13,
+            &[_]u64{}));
+}
+
+test "nothing is found when the left and right bounds cross" {
+    testing.expectError(SearchError.ValueAbsent,
+        binary_search.binarySearch(isize, 13,
+            &[_]isize{1, 2}));
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard binary-search practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.