### PR TITLE
Flatten queen-attack authors

### DIFF
--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,9 +1,6 @@
 {
   "authors": [
-    {
-      "github_username": "massivelivefun",
-      "exercism_username": "massivelivefun"
-    }
+    "massivelivefun"
   ],
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "files": {


### PR DESCRIPTION
This pull request adds the following:

- A correction to the queen-attack exercise config.json file. This will flatten the authors and contributors of the exercises into one name.