### PR TITLE
Add secret-handshake practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -340,6 +340,30 @@
           "type-coercion"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "bf256ae9-9e65-48bf-8f27-fde487c05856",
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "practices": [
+          "allocators",
+          "bitwise-operations",
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "functions",
+          "importing"
+        ],
+        "prerequisites": [
+          "allocators",
+          "bitwise-operations",
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "functions",
+          "importing"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Description
+
+> There are 10 types of people in the world: Those who understand
+> binary, and those who don't.
+
+You and your fellow cohort of those in the "know" when it comes to
+binary decide to come up with a secret "handshake".
+
+```text
+1 = wink
+10 = double blink
+100 = close your eyes
+1000 = jump
+
+
+10000 = Reverse the order of the operations in the secret handshake.
+```
+
+Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.
+
+Here's a couple of examples:
+
+Given the input 3, the function would return the array
+["wink", "double blink"] because 3 is 11 in binary.
+
+Given the input 19, the function would return the array
+["double blink", "wink"] because 19 is 10011 in binary.
+Notice that the addition of 16 (10000 in binary)
+has caused the array to be reversed.

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
+  "authors": [
+    "massivelivefun"
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "secret_handshake.zig"
+    ],
+    "test": [
+      "test_secret_handshake.zig"
+    ]
+  },
+  "source": "Bert, in Mary Poppins",
+  "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"
+}

--- a/exercises/practice/secret-handshake/.meta/example.zig
+++ b/exercises/practice/secret-handshake/.meta/example.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const mem = std.mem;
+
+pub const Signal = enum(u2) {
+    wink,
+    double_blink,
+    close_your_eyes,
+    jump,
+};
+
+pub fn calculateHandshake(
+    allocator: *mem.Allocator,
+    number: isize
+) mem.Allocator.Error![]const Signal {
+    var list = std.ArrayList(Signal).init(allocator);
+    defer list.deinit();
+    if (isFlipped(number, 0b1)) {
+        try list.append(Signal.wink);
+    }
+    if (isFlipped(number, 0b10)) {
+        try list.append(Signal.double_blink);
+    }
+    if (isFlipped(number, 0b100)) {
+        try list.append(Signal.close_your_eyes);
+    }
+    if (isFlipped(number, 0b1000)) {
+        try list.append(Signal.jump);
+    }
+    // Reverse the ArrayList's contents.
+    if (isFlipped(number, 0b10000) and list.items.len > 1) {
+        var i: usize = 0;
+        var j: usize = list.items.len - 1;
+        while (i < j) : ({ i += 1; j -= 1; }) {
+            var temp = list.items[i];
+            list.items[i] = list.items[j];
+            list.items[j] = temp;
+        }
+    }
+    return list.toOwnedSlice();
+}
+
+inline fn isFlipped(number: isize, bit_mask: isize) bool {
+    return (number & bit_mask) > 0;
+}

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -1,0 +1,47 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[b8496fbd-6778-468c-8054-648d03c4bb23]
+description = "wink for 1"
+include = true
+
+[83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
+description = "double blink for 10"
+include = true
+
+[0e20e466-3519-4134-8082-5639d85fef71]
+description = "close your eyes for 100"
+include = true
+
+[b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
+description = "jump for 1000"
+include = true
+
+[40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
+description = "combine two actions"
+include = true
+
+[9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
+description = "reverse two actions"
+include = true
+
+[0b828205-51ca-45cd-90d5-f2506013f25f]
+description = "reversing one action gives the same action"
+include = true
+
+[9949e2ac-6c9c-4330-b685-2089ab28b05f]
+description = "reversing no actions still gives no actions"
+include = true
+
+[23fdca98-676b-4848-970d-cfed7be39f81]
+description = "all possible actions"
+include = true
+
+[ae8fe006-d910-4d6f-be00-54b7c3799e79]
+description = "reverse all possible actions"
+include = true
+
+[3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
+description = "do nothing for zero"
+include = true

--- a/exercises/practice/secret-handshake/secret_handshake.zig
+++ b/exercises/practice/secret-handshake/secret_handshake.zig
@@ -1,0 +1,6 @@
+pub fn calculateHandshake(
+    allocator: *mem.Allocator,
+    number: isize
+) mem.Allocator.Error![]const Signal {
+    @panic("please implement the calculateHandshake function");
+}

--- a/exercises/practice/secret-handshake/test_secret_handshake.zig
+++ b/exercises/practice/secret-handshake/test_secret_handshake.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const testing = std.testing;
+
+const secret_handshake = @import("secret_handshake.zig");
+
+test "wink for 1" {
+    const expected = &[_]secret_handshake.Signal{.wink};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 1);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "double blink for 10" {
+    const expected = &[_]secret_handshake.Signal{.double_blink};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 2);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "close your eyes for 100" {
+    const expected = &[_]secret_handshake.Signal{.close_your_eyes};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 4);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "jump for 1000" {
+    const expected = &[_]secret_handshake.Signal{.jump};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 8);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "combine two actions" {
+    const expected = &[_]secret_handshake.Signal{.wink, .double_blink};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 3);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "reverse two actions" {
+    const expected = &[_]secret_handshake.Signal{.double_blink, .wink};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 19);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "reversing one action gives the same action" {
+    const expected = &[_]secret_handshake.Signal{.jump};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 24);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "reversing no actions still gives no actions" {
+    const expected = &[_]secret_handshake.Signal{};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 16);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "all possible actions" {
+    const expected = &[_]secret_handshake.Signal{
+        .wink, .double_blink, .close_your_eyes, .jump};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 15);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "reverse all possible actions" {
+    const expected = &[_]secret_handshake.Signal{
+        .jump, .close_your_eyes, .double_blink, .wink};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 31);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}
+
+test "do nothing for zero" {
+    const expected = &[_]secret_handshake.Signal{};
+    var actual = try secret_handshake.calculateHandshake(testing.allocator, 0);
+    defer testing.allocator.free(actual);
+    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard secret-handshake practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.