### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "files": {
     "example": [

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "files": {
     "example": [

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "blurb": "Convert a resistor band's color to its numeric representation",
   "files": {
     "example": [

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -3,6 +3,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "files": {
     "example": [
       ".meta/example.zig"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "files": {
     "example": [

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "files": {
     "example": [

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -2,6 +2,10 @@
   "authors": [
     "massivelivefun"
   ],
+  "contributors": [
+    "ErikSchierboom",
+    "iHiD"
+  ],
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "files": {
     "example": [


### PR DESCRIPTION
_If you got tagged in this PR, it is because you are being credited for work you've done in the past on Exercism here, and we want to ensure you don't miss out on the recognition you deserve 🙂_

---

With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercises' `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, already contain authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Maintainer TODO list

These are the things you, the maintainers, should do:

- [ ] Check the authors and contributors, adding/removing users where the data is missing or incorrect
- [ ] Double-check any renamed Practice Exercises
- [ ] Check for Practice Exercises with missing authors, which are most likely due to the author not being on GitHub anymore 
- [ ] Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

**For clarity, authors should be the people who originally created the exercise on this track. Contributors should be people who have substantially contributed to that exercise. PRs for typos or multiple-exercise PRs do not automatically mean someone should be considered a contributor to that exercise. Those non-exercise-specific contributions will get recognition through Exercism's reputation system in v3.**

If you find something needs updating, just push a new commit to this PR.

## Automatic Merging

We will automatically merge this PR before we launch v3, but will give the maximum time we can to maintainers to review it first.

---

_The rest of this issue explains how this PR has been generated. You do not **need** to read it._

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits touched that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Any commit that we can associate with a Practice Exercise is used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise.
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors and any co-authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author and any co-authors of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors and any co-authors of those commits
3. Add the GitHub usernames of the Git commit authors and any co-authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author and any co-authors. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There are a small number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Tracking

https://github.com/exercism/v3-launch/issues/24

---

cc @ErikSchierboom, @iHiD, @massivelivefun as you are referenced in this PR
