### PR TITLE
Add isogram practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -364,6 +364,26 @@
           "importing"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "bf256ae9-9e65-48bf-8f27-fde487c05856",
+        "slug": "isogram",
+        "name": "Isogram",
+        "practices": [
+          "builtin-functions",
+          "bitwise-operations",
+          "conditionals",
+          "control-flow",
+          "functions"
+        ],
+        "prerequisites": [
+          "builtin-functions",
+          "bitwise-operations",
+          "conditionals",
+          "control-flow",
+          "functions"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/isogram/.docs/instructions.md
+++ b/exercises/practice/isogram/.docs/instructions.md
@@ -1,0 +1,14 @@
+# Description
+
+Determine if a word or phrase is an isogram.
+
+An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter, however spaces and hyphens are allowed to appear multiple times.
+
+Examples of isograms:
+
+- lumberjacks
+- background
+- downstream
+- six-year-old
+
+The word *isograms*, however, is not an isogram, because the s repeats.

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "blurb": "Determine if a word or phrase is an isogram.",
+  "authors": [
+    "massivelivefun"
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "isogram.zig"
+    ],
+    "test": [
+      "test_isogram.zig"
+    ]
+  },
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Isogram"
+}

--- a/exercises/practice/isogram/.meta/example.zig
+++ b/exercises/practice/isogram/.meta/example.zig
@@ -1,0 +1,23 @@
+pub fn isIsogram(str: []const u8) bool {
+    var mask: u32 = 0;
+    for (str) |value| {
+        switch (value) {
+            'a'...'z' => {
+                if (mask & @as(u32, 1) << @truncate(u5, value - 'a') == 0) {
+                    mask |= @as(u32, 1) << @truncate(u5, value - 'a');
+                } else {
+                    return false;
+                }
+            },
+            'A'...'Z' => {
+                if (mask & @as(u32, 1) << @truncate(u5, value - 'A') == 0) {
+                    mask |= @as(u32, 1) << @truncate(u5, value - 'A');
+                } else {
+                    return false;
+                }
+            },
+            else => continue,
+        }
+    }
+    return true;
+}

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,0 +1,55 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+include = true
+
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+include = true
+
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+include = true
+
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+include = true
+
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+include = true
+
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+include = true
+
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+include = true
+
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+include = true
+
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+include = true
+
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+include = true
+
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+include = true
+
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+include = true
+
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+include = true

--- a/exercises/practice/isogram/isogram.zig
+++ b/exercises/practice/isogram/isogram.zig
@@ -1,0 +1,3 @@
+pub fn isIsogram(str: []const u8) bool {
+    @panic("please implement the isIsogram function");
+}

--- a/exercises/practice/isogram/test_isogram.zig
+++ b/exercises/practice/isogram/test_isogram.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const testing = std.testing;
+
+const isogram = @import("isogram.zig");
+
+test "empty string" {
+    testing.expect(isogram.isIsogram(""));
+}
+
+test "isogram with only lower case characters" {
+    testing.expect(isogram.isIsogram("isogram"));
+}
+
+test "word with one duplicated character" {
+    testing.expect(!isogram.isIsogram("eleven"));
+}
+
+test "word with one duplicated character from the end of the alphabet" {
+    testing.expect(!isogram.isIsogram("zzyzx"));
+}
+
+test "word with one duplicated character from the end of the alphabet" {
+    testing.expect(isogram.isIsogram("subdermatoglyphic"));
+}
+
+test "word with duplicated character in mixed case" {
+    testing.expect(!isogram.isIsogram("Alphabet"));
+}
+
+test "word with duplicated character in mixed case, lowercase first" {
+    testing.expect(!isogram.isIsogram("alphAbet"));
+}
+
+test "hypothetical isogrammic word with hyphen" {
+    testing.expect(isogram.isIsogram("thumbscrew-japingly"));
+}
+
+test "hypothetical word with duplicated character following hyphen" {
+    testing.expect(!isogram.isIsogram("thumbscrew-jappingly"));
+}
+
+test "isogram with duplicated hyphen" {
+    testing.expect(isogram.isIsogram("six-year-old"));
+}
+
+test "made-up name that is an isogram" {
+    testing.expect(isogram.isIsogram("Emily Jung Schwartzkopf"));
+}
+
+test "duplicated character in the middle" {
+    testing.expect(!isogram.isIsogram("accentor"));
+}
+
+test "same first and last characters" {
+    testing.expect(!isogram.isIsogram("angola"));
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard isogram practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.