### PR TITLE
[CI] Validate v 0.7.1 work in linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install Zig
       run: |
-        curl -o zig.tar.xz https://ziglang.org/download/0.7.1/zig-linux-x86_64-0.7.0.tar.xz
+        curl -o zig.tar.xz https://ziglang.org/download/0.7.1/zig-linux-x86_64-0.7.1.tar.xz
         tar xJf zig.tar.xz
         mkdir -p $HOME/bin
         ln -s $(pwd)/zig-*/zig $HOME/bin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install Zig
       run: |
-        curl -o zig.tar.xz https://ziglang.org/download/0.7.0/zig-linux-x86_64-0.7.0.tar.xz
+        curl -o zig.tar.xz https://ziglang.org/download/0.7.1/zig-linux-x86_64-0.7.0.tar.xz
         tar xJf zig.tar.xz
         mkdir -p $HOME/bin
         ln -s $(pwd)/zig-*/zig $HOME/bin


### PR DESCRIPTION
Finding that many of the exercises are not working on  0.7.1