### PR TITLE
Add proverb practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -384,6 +384,28 @@
           "functions"
         ],
         "difficulty": 1
+      },
+      {
+        "uuid": "7b7db815-5e14-477e-8012-f7719561dd8f",
+        "slug": "proverb",
+        "name": "Proverb",
+        "practices": [
+          "allocators",
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "functions",
+          "slices"
+        ],
+        "prerequisites": [
+          "allocators",
+          "conditionals",
+          "control-flow",
+          "error-sets",
+          "functions",
+          "slices"
+        ],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/proverb/.docs/instructions.md
+++ b/exercises/practice/proverb/.docs/instructions.md
@@ -1,0 +1,17 @@
+# Description
+
+For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
+
+Given a list of inputs, generate the relevant proverb. For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
+
+```text
+For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+For want of a rider the message was lost.
+For want of a message the battle was lost.
+For want of a battle the kingdom was lost.
+And all for the want of a nail.
+```
+
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
+  "authors": [
+    "massivelivefun"
+  ],
+  "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
+    "solution": [
+      "proverb.zig"
+    ],
+    "test": [
+      "test_proverb.zig"
+    ]
+  },
+  "source": "Wikipedia",
+  "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"
+}

--- a/exercises/practice/proverb/.meta/example.zig
+++ b/exercises/practice/proverb/.meta/example.zig
@@ -13,13 +13,13 @@ pub fn recite(
         var i: usize = 0;
         while (i < words.len - 1) : (i += 1) {
             main_slice[i] = try fmt.allocPrint(allocator,
-                "For want of a {s} the {s} was lost.",
+                "For want of a {s} the {s} was lost.\n",
                     .{words[i], words[i + 1]});
         }
     }
     if (words.len > 0) {
         main_slice[main_slice.len - 1] = try fmt.allocPrint(allocator,
-            "And all for the want of a {s}.", .{words[0]});
+            "And all for the want of a {s}.\n", .{words[0]});
     }
     return main_slice;
 }

--- a/exercises/practice/proverb/.meta/example.zig
+++ b/exercises/practice/proverb/.meta/example.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const fmt = std.fmt;
+const mem = std.mem;
+
+pub fn recite(
+    allocator: *mem.Allocator,
+    words: []const []const u8
+) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
+
+    var main_slice = try allocator.alloc([]u8, words.len);
+
+    if (words.len > 1) {
+        var i: usize = 0;
+        while (i < words.len - 1) : (i += 1) {
+            main_slice[i] = try fmt.allocPrint(allocator,
+                "For want of a {s} the {s} was lost.",
+                    .{words[i], words[i + 1]});
+        }
+    }
+    if (words.len > 0) {
+        main_slice[main_slice.len - 1] = try fmt.allocPrint(allocator,
+            "And all for the want of a {s}.", .{words[0]});
+    }
+    return main_slice;
+}

--- a/exercises/practice/proverb/.meta/tests.toml
+++ b/exercises/practice/proverb/.meta/tests.toml
@@ -1,0 +1,27 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[e974b73e-7851-484f-8d6d-92e07fe742fc]
+description = "zero pieces"
+include = true
+
+[2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4]
+description = "one piece"
+include = true
+
+[d9d0a8a1-d933-46e2-aa94-eecf679f4b0e]
+description = "two pieces"
+include = true
+
+[c95ef757-5e94-4f0d-a6cb-d2083f5e5a83]
+description = "three pieces"
+include = true
+
+[433fb91c-35a2-4d41-aeab-4de1e82b2126]
+description = "full proverb"
+include = true
+
+[c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7]
+description = "four pieces modernized"
+include = true

--- a/exercises/practice/proverb/proverb.zig
+++ b/exercises/practice/proverb/proverb.zig
@@ -1,0 +1,6 @@
+pub fn recite(
+    allocator: *mem.Allocator,
+    words: []const []const u8
+) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
+    @panic("please implement the recite function");
+}

--- a/exercises/practice/proverb/test_proverb.zig
+++ b/exercises/practice/proverb/test_proverb.zig
@@ -26,7 +26,7 @@ test "one piece" {
     const input_array = [_][]const u8 { first_slice };
     const input_slice = &input_array;
 
-    const first_expected = "And all for the want of a nail.".*;
+    const first_expected = "And all for the want of a nail.\n".*;
     const first_expected_slice = &first_expected;
     const expected_array = [_][]const u8 { first_expected_slice };
     const expected = &expected_array;
@@ -51,9 +51,9 @@ test "two pieces" {
     const input_array = [_][]const u8 { first_slice, second_slice };
     const input_slice = &input_array;
 
-    const first_expected = "For want of a nail the shoe was lost.".*;
+    const first_expected = "For want of a nail the shoe was lost.\n".*;
     const first_expected_slice = &first_expected ;
-    const second_expected = "And all for the want of a nail.".*;
+    const second_expected = "And all for the want of a nail.\n".*;
     const second_expected_slice = &second_expected;
     const expected_array = [_][]const u8 { first_expected_slice,
         second_expected_slice };
@@ -82,11 +82,11 @@ test "three pieces" {
         third_slice };
     const input_slice = &input_array;
 
-    const first_expected = "For want of a nail the shoe was lost.".*;
+    const first_expected = "For want of a nail the shoe was lost.\n".*;
     const first_expected_slice = &first_expected;
-    const second_expected = "For want of a shoe the horse was lost.".*;
+    const second_expected = "For want of a shoe the horse was lost.\n".*;
     const second_expected_slice = &second_expected;
-    const third_expected = "And all for the want of a nail.".*;
+    const third_expected = "And all for the want of a nail.\n".*;
     const third_expected_slice = &third_expected;
     const expected_array = [_][]const u8 { first_expected_slice,
         second_expected_slice, third_expected_slice };
@@ -123,19 +123,19 @@ test "full proverb" {
         third_slice, fourth_slice, fifth_slice, sixth_slice, seventh_slice };
     const input_slice = &input_array;
 
-    const first_expected = "For want of a nail the shoe was lost.".*;
+    const first_expected = "For want of a nail the shoe was lost.\n".*;
     const first_expected_slice = &first_expected;
-    const second_expected = "For want of a shoe the horse was lost.".*;
+    const second_expected = "For want of a shoe the horse was lost.\n".*;
     const second_expected_slice = &second_expected;
-    const third_expected = "For want of a horse the rider was lost.".*;
+    const third_expected = "For want of a horse the rider was lost.\n".*;
     const third_expected_slice = &third_expected;
-    const fourth_expected = "For want of a rider the message was lost.".*;
+    const fourth_expected = "For want of a rider the message was lost.\n".*;
     const fourth_expected_slice = &fourth_expected;
-    const fifth_expected = "For want of a message the battle was lost.".*;
+    const fifth_expected = "For want of a message the battle was lost.\n".*;
     const fifth_expected_slice = &fifth_expected;
-    const sixth_expected = "For want of a battle the kingdom was lost.".*;
+    const sixth_expected = "For want of a battle the kingdom was lost.\n".*;
     const sixth_expected_slice = &sixth_expected;
-    const seventh_expected = "And all for the want of a nail.".*;
+    const seventh_expected = "And all for the want of a nail.\n".*;
     const seventh_expected_slice = &seventh_expected;
     const expected_array = [_][]const u8 { first_expected_slice,
         second_expected_slice, third_expected_slice, fourth_expected_slice,
@@ -167,13 +167,13 @@ test "four pieces modernized" {
         third_slice, fourth_slice };
     const input_slice = &input_array;
 
-    const first_expected = "For want of a pin the gun was lost.".*;
+    const first_expected = "For want of a pin the gun was lost.\n".*;
     const first_expected_slice = &first_expected;
-    const second_expected = "For want of a gun the soldier was lost.".*;
+    const second_expected = "For want of a gun the soldier was lost.\n".*;
     const second_expected_slice = &second_expected;
-    const third_expected = "For want of a soldier the battle was lost.".*;
+    const third_expected = "For want of a soldier the battle was lost.\n".*;
     const third_expected_slice = &third_expected;
-    const fourth_expected = "And all for the want of a pin.".*;
+    const fourth_expected = "And all for the want of a pin.\n".*;
     const fourth_expected_slice = &fourth_expected;
     const expected_array = [_][]const u8 { first_expected_slice,
         second_expected_slice, third_expected_slice, fourth_expected_slice };

--- a/exercises/practice/proverb/test_proverb.zig
+++ b/exercises/practice/proverb/test_proverb.zig
@@ -1,0 +1,192 @@
+const std = @import("std");
+const testing = std.testing;
+
+const proverb = @import("proverb.zig");
+
+test "zero pieces" {
+    const array_long = [_][]const u8 {};
+    const input_slice = &array_long;
+
+    const expected = input_slice;
+
+    const actual = try proverb.recite(testing.allocator, input_slice);
+
+    testing.expectEqualSlices([]const u8, expected, actual);
+
+    // The free here doesn't actually free memory since a zero sized heap
+    // allocation doesn't actually point to anything important. So the free
+    // method on the allocator just quickly exits if what it points to has
+    // has a byte length of zero.
+    testing.allocator.free(actual);
+}
+
+test "one piece" {
+    const first_input = "nail".*;
+    const first_slice = &first_input;
+    const input_array = [_][]const u8 { first_slice };
+    const input_slice = &input_array;
+
+    const first_expected = "And all for the want of a nail.".*;
+    const first_expected_slice = &first_expected;
+    const expected_array = [_][]const u8 { first_expected_slice };
+    const expected = &expected_array;
+
+    const actual = try proverb.recite(testing.allocator, input_slice);
+
+    for (expected) |expected_slice, i| {
+        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+    }
+
+    for (actual) |inner_slice| {
+        testing.allocator.free(inner_slice);
+    }
+    testing.allocator.free(actual);
+}
+
+test "two pieces" {
+    const first_input = "nail".*;
+    const first_slice = &first_input;
+    const second_input = "shoe".*;
+    const second_slice = &second_input;
+    const input_array = [_][]const u8 { first_slice, second_slice };
+    const input_slice = &input_array;
+
+    const first_expected = "For want of a nail the shoe was lost.".*;
+    const first_expected_slice = &first_expected ;
+    const second_expected = "And all for the want of a nail.".*;
+    const second_expected_slice = &second_expected;
+    const expected_array = [_][]const u8 { first_expected_slice,
+        second_expected_slice };
+    const expected = &expected_array;
+
+    const actual = try proverb.recite(testing.allocator, input_slice);
+
+    for (expected) |expected_slice, i| {
+        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+    }
+
+    for (actual) |inner_slice| {
+        testing.allocator.free(inner_slice);
+    }
+    testing.allocator.free(actual);
+}
+
+test "three pieces" {
+    const first_input = "nail".*;
+    const first_slice = &first_input;
+    const second_input = "shoe".*;
+    const second_slice = &second_input;
+    const third_input = "horse".*;
+    const third_slice = &third_input;
+    const input_array = [_][]const u8 { first_slice, second_slice,
+        third_slice };
+    const input_slice = &input_array;
+
+    const first_expected = "For want of a nail the shoe was lost.".*;
+    const first_expected_slice = &first_expected;
+    const second_expected = "For want of a shoe the horse was lost.".*;
+    const second_expected_slice = &second_expected;
+    const third_expected = "And all for the want of a nail.".*;
+    const third_expected_slice = &third_expected;
+    const expected_array = [_][]const u8 { first_expected_slice,
+        second_expected_slice, third_expected_slice };
+    const expected = &expected_array;
+
+    const actual = try proverb.recite(testing.allocator, input_slice);
+
+    for (expected) |expected_slice, i| {
+        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+    }
+
+    for (actual) |inner_slice| {
+        testing.allocator.free(inner_slice);
+    }
+    testing.allocator.free(actual);
+}
+
+test "full proverb" {
+    const first_input = "nail".*;
+    const first_slice = &first_input;
+    const second_input = "shoe".*;
+    const second_slice = &second_input;
+    const third_input = "horse".*;
+    const third_slice = &third_input;
+    const fourth_input = "rider".*;
+    const fourth_slice = &fourth_input;
+    const fifth_input = "message".*;
+    const fifth_slice = &fifth_input;
+    const sixth_input = "battle".*;
+    const sixth_slice = &sixth_input;
+    const seventh_input = "kingdom".*;
+    const seventh_slice = &seventh_input;
+    const input_array = [_][]const u8 { first_slice, second_slice,
+        third_slice, fourth_slice, fifth_slice, sixth_slice, seventh_slice };
+    const input_slice = &input_array;
+
+    const first_expected = "For want of a nail the shoe was lost.".*;
+    const first_expected_slice = &first_expected;
+    const second_expected = "For want of a shoe the horse was lost.".*;
+    const second_expected_slice = &second_expected;
+    const third_expected = "For want of a horse the rider was lost.".*;
+    const third_expected_slice = &third_expected;
+    const fourth_expected = "For want of a rider the message was lost.".*;
+    const fourth_expected_slice = &fourth_expected;
+    const fifth_expected = "For want of a message the battle was lost.".*;
+    const fifth_expected_slice = &fifth_expected;
+    const sixth_expected = "For want of a battle the kingdom was lost.".*;
+    const sixth_expected_slice = &sixth_expected;
+    const seventh_expected = "And all for the want of a nail.".*;
+    const seventh_expected_slice = &seventh_expected;
+    const expected_array = [_][]const u8 { first_expected_slice,
+        second_expected_slice, third_expected_slice, fourth_expected_slice,
+        fifth_expected_slice, sixth_expected_slice, seventh_expected_slice };
+    const expected = &expected_array;
+
+    const actual = try proverb.recite(testing.allocator, input_slice);
+
+    for (expected) |expected_slice, i| {
+        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+    }
+
+    for (actual) |inner_slice| {
+        testing.allocator.free(inner_slice);
+    }
+    testing.allocator.free(actual);
+}
+
+test "four pieces modernized" {
+    const first_input = "pin".*;
+    const first_slice = &first_input;
+    const second_input = "gun".*;
+    const second_slice = &second_input;
+    const third_input = "soldier".*;
+    const third_slice = &third_input;
+    const fourth_input = "battle".*;
+    const fourth_slice = &fourth_input;
+    const input_array = [_][]const u8 { first_slice, second_slice,
+        third_slice, fourth_slice };
+    const input_slice = &input_array;
+
+    const first_expected = "For want of a pin the gun was lost.".*;
+    const first_expected_slice = &first_expected;
+    const second_expected = "For want of a gun the soldier was lost.".*;
+    const second_expected_slice = &second_expected;
+    const third_expected = "For want of a soldier the battle was lost.".*;
+    const third_expected_slice = &third_expected;
+    const fourth_expected = "And all for the want of a pin.".*;
+    const fourth_expected_slice = &fourth_expected;
+    const expected_array = [_][]const u8 { first_expected_slice,
+        second_expected_slice, third_expected_slice, fourth_expected_slice };
+    const expected = &expected_array;
+
+    const actual = try proverb.recite(testing.allocator, input_slice);
+
+    for (expected) |expected_slice, i| {
+        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+    }
+
+    for (actual) |inner_slice| {
+        testing.allocator.free(inner_slice);
+    }
+    testing.allocator.free(actual);
+}


### PR DESCRIPTION
This pull request adds the following:

- A Zig implementation of the Exercism standard proverb practice exercise.

Note: This practice exercise's "practices" and "prerequisites" keys within the track's config.json file will have to change at a later date. The placeholder values are accurate to what has to be understood before grasping this practice exercise. It's just that those key's values are speculative as to what concepts will exist and how they will flow when later designed and implemented.