### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -342,7 +342,7 @@
         "difficulty": 1
       },
       {
-        "uuid": "bf256ae9-9e65-48bf-8f27-fde487c05856",
+        "uuid": "ba0ab298-3fb4-47e1-87f0-0644a405502e",
         "slug": "secret-handshake",
         "name": "Secret Handshake",
         "practices": [
@@ -366,7 +366,7 @@
         "difficulty": 1
       },
       {
-        "uuid": "bf256ae9-9e65-48bf-8f27-fde487c05856",
+        "uuid": "93a9b5bd-b495-4a7d-86fe-b71fd0343336",
         "slug": "isogram",
         "name": "Isogram",
         "practices": [


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
