### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello_world.zig
+++ b/exercises/practice/hello-world/hello_world.zig
@@ -1,3 +1,3 @@
 pub fn hello() []const u8 {
-    return "Goodbye, world!";
+    return "Goodbye, Mars!";
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46