### PR TITLE
Remove prerequisites from `hello-world`

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,9 +28,6 @@
           "type-coercion"
         ],
         "prerequisites": [
-          "functions",
-          "slices",
-          "type-coercion"
         ],
         "difficulty": 1
       },


### PR DESCRIPTION
From [the spec](https://github.com/exercism/docs/blob/14de83e5305b/building/configlet/lint.md#rule-configjson-file-is-valid):

> - The `"exercises.practice[].prerequisites"` value must be an empty
  array if `"exercises.practice[].slug"` is equal to `hello-world`

This would otherwise cause `configlet lint` to produce an error in the future (and might stop `hello-world` from being unlocked!).