### PR TITLE
fixup: get tests working again

### DIFF
--- a/exercises/practice/binary-search/test_binary_search.zig
+++ b/exercises/practice/binary-search/test_binary_search.zig
@@ -5,67 +5,67 @@ const binary_search = @import("binary_search.zig");
 const SearchError = binary_search.SearchError;
 
 test "finds a value in an array with one element" {
-    comptime testing.expectEqual(0,
+    comptime try testing.expectEqual(0,
         try binary_search.binarySearch(i4, 6,
             &[_]i4{6}));
 }
 
 test "finds a value in the middle of an array" {
-    comptime testing.expectEqual(3,
+    comptime try testing.expectEqual(3,
         try binary_search.binarySearch(u4, 6,
             &[_]u4{1, 3, 4, 6, 8, 9, 11}));
 }
 
 test "finds a value at the beginning of an array" {
-    comptime testing.expectEqual(0,
+    comptime try testing.expectEqual(0,
         try binary_search.binarySearch(i8, 1,
             &[_]i8{1, 3, 4, 6, 8, 9, 11}));
 }
 
 test "finds a value at the end of an array" {
-    comptime testing.expectEqual(6,
+    comptime try testing.expectEqual(6,
         try binary_search.binarySearch(u8, 11,
             &[_]u8{1, 3, 4, 6, 8, 9, 11}));
 }
 
 test "finds a value in an array of odd length" {
-    comptime testing.expectEqual(5,
+    comptime try testing.expectEqual(5,
         try binary_search.binarySearch(i16, 21,
             &[_]i16{1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634}));
 }
 
 test "finds a value in an array of even length" {
-    comptime testing.expectEqual(5,
+    comptime try testing.expectEqual(5,
         try binary_search.binarySearch(u16, 21,
             &[_]u16{1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377}));
 }
 
 test "identifies that a value is not included in the array" {
-    testing.expectError(SearchError.ValueAbsent,
+    try testing.expectError(SearchError.ValueAbsent,
         binary_search.binarySearch(i32, 7,
             &[_]i32{1, 3, 4, 6, 8, 9, 11}));
 }
 
 test "a value smaller than the arrays smallest value is not found" {
-    testing.expectError(SearchError.ValueAbsent,
+    try testing.expectError(SearchError.ValueAbsent,
         binary_search.binarySearch(u32, 0,
             &[_]u32{1, 3, 4, 6, 8, 9, 11}));
 }
 
 test "a value larger than the arrays largest value is not found" {
-    testing.expectError(SearchError.ValueAbsent,
+    try testing.expectError(SearchError.ValueAbsent,
         binary_search.binarySearch(i64, 13,
             &[_]i64{1, 3, 4, 6, 8, 9, 11}));
 }
 
 test "nothing is found in an empty array" {
-    testing.expectError(SearchError.EmptyBuffer,
+    try testing.expectError(SearchError.EmptyBuffer,
         binary_search.binarySearch(u64, 13,
             &[_]u64{}));
 }
 
 test "nothing is found when the left and right bounds cross" {
-    testing.expectError(SearchError.ValueAbsent,
+    try testing.expectError(SearchError.ValueAbsent,
         binary_search.binarySearch(isize, 13,
             &[_]isize{1, 2}));
 }

--- a/exercises/practice/collatz-conjecture/test_collatz_conjecture.zig
+++ b/exercises/practice/collatz-conjecture/test_collatz_conjecture.zig
@@ -7,35 +7,35 @@ const ComputationError = collatz_conjecture.ComputationError;
 test "zero steps for one" {
     const expected = 0;
     const actual = comptime try collatz_conjecture.steps(1);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "divide if even" {
     const expected = 4;
     const actual = comptime try collatz_conjecture.steps(16);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "even and odd steps" {
     const expected = 9;
     const actual = comptime try collatz_conjecture.steps(12);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "large number of even and odd steps" {
     const expected = 152;
     const actual = comptime try collatz_conjecture.steps(1000000);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "zero is an error" {
     const expected = ComputationError.IllegalArgument;
     const actual = comptime collatz_conjecture.steps(0);
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "negative value is an error" {
     const expected = ComputationError.IllegalArgument;
     const actual = comptime collatz_conjecture.steps(-15);
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }

--- a/exercises/practice/darts/test_darts.zig
+++ b/exercises/practice/darts/test_darts.zig
@@ -7,89 +7,89 @@ test "missed target" {
     const coordinate = comptime darts.Coordinate.init(-9.0, 9.0);
     const expected = 0;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "on the outer circle" {
     const coordinate = comptime darts.Coordinate.init(0.0, 10.0);
     const expected = 1;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "on the middle circle" {
     const coordinate = comptime darts.Coordinate.init(-5.0, 0.0);
     const expected = 5;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "on the inner circle" {
     const coordinate = comptime darts.Coordinate.init(0.0, -1.0);
     const expected = 10;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "exactly on center" {
     const coordinate = comptime darts.Coordinate.init(0.0, 0.0);
     const expected = 10;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "near the center" {
     const coordinate = comptime darts.Coordinate.init(-0.1, -0.1);
     const expected = 10;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "just within the inner circle" {
     const coordinate = comptime darts.Coordinate.init(0.7, 0.7);
     const expected = 10;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "just outside the inner circle" {
     const coordinate = comptime darts.Coordinate.init(0.8, -0.8);
     const expected = 5;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "just within the middle circle" {
     const coordinate = comptime darts.Coordinate.init(3.5, -3.5);
     const expected = 5;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "just outside the middle circle" {
     const coordinate = comptime darts.Coordinate.init(-3.6, -3.6);
     const expected = 1;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "just within the outer circle" {
     const coordinate = comptime darts.Coordinate.init(-7.0, 7.0);
     const expected = 1;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "just outside the outer circle" {
     const coordinate = comptime darts.Coordinate.init(7.1, -7.1);
     const expected = 0;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "asymmetric position between the inner and middle circles" {
     const coordinate = comptime darts.Coordinate.init(0.5, -4.0);
     const expected = 5;
     const actual = comptime coordinate.score();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }

--- a/exercises/practice/difference-of-squares/test_difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/test_difference_of_squares.zig
@@ -6,53 +6,53 @@ const difference_of_squares = @import("difference_of_squares.zig");
 test "square of sum up to 1" {
     const expected = 1;
     const actual = comptime difference_of_squares.square_of_sum(1);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "square of sum up to 5" {
     const expected = 225;
     const actual = comptime difference_of_squares.square_of_sum(5);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "square of sum up to 100" {
     const expected = 25502500;
     const actual = comptime difference_of_squares.square_of_sum(100);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "sum of squares up to 1" {
     const expected = 1;
     const actual = comptime difference_of_squares.sum_of_squares(1);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "sum of squares up to 5" {
     const expected = 55;
     const actual = comptime difference_of_squares.sum_of_squares(5);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "sum of squares up to 100" {
     const expected = 338350;
     const actual = comptime difference_of_squares.sum_of_squares(100);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "difference of squares up to 1" {
     const expected = 0;
     const actual = comptime difference_of_squares.difference_of_squares(1);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "difference of squares up to 5" {
     const expected = 170;
     const actual = comptime difference_of_squares.difference_of_squares(5);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "difference of squares up to 100" {
     const expected = 25164150;
     const actual = comptime difference_of_squares.difference_of_squares(100);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }

--- a/exercises/practice/grains/test_grains.zig
+++ b/exercises/practice/grains/test_grains.zig
@@ -7,65 +7,65 @@ const ChessboardError = grains.ChessboardError;
 test "grains on square 1" {
     const expected = 1;
     const actual = comptime try grains.square(1);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 2" {
     const expected = 2;
     const actual = comptime try grains.square(2);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 3" {
     const expected = 4;
     const actual = comptime try grains.square(3);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 4" {
     const expected = 8;
     const actual = comptime try grains.square(4);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 16" {
     const expected = 32768;
     const actual = comptime try grains.square(16);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 32" {
     const expected = 2147483648;
     const actual = comptime try grains.square(32);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 64" {
     const expected = 9223372036854775808;
     const actual = comptime try grains.square(64);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "square 0 raises an exception" {
     const expected = ChessboardError.IndexOutOfBounds;
     const actual = comptime grains.square(0);
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "negative square raises an expection" {
     const expected = ChessboardError.IndexOutOfBounds;
     const actual = comptime grains.square(-1);
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "square greater than 64 raises an exception" {
     const expected = ChessboardError.IndexOutOfBounds;
     const actual = comptime grains.square(65);
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "returns the total number of grains on the board" {
     const expected = 18446744073709551615;
     const actual = comptime grains.total();
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }

--- a/exercises/practice/hamming/test_hamming.zig
+++ b/exercises/practice/hamming/test_hamming.zig
@@ -7,55 +7,55 @@ const DNAError = hamming.DNAError;
 test "empty strands" {
     const expected = DNAError.EmptyDNAStrands;
     const actual = comptime hamming.compute("", "");
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "single letter identical strands" {
     const expected = 0;
     const actual = comptime try hamming.compute("A", "A");
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "single letter different strands" {
     const expected = 1;
     const actual = comptime try hamming.compute("G", "T");
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "long identical strands" {
     const expected = 0;
     const actual = comptime try hamming
         .compute("GGACTGAAATCTG", "GGACTGAAATCTG");
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "long different strands" {
     const expected = 9;
     const actual = comptime try hamming
         .compute("GGACGGATTCTG", "AGGACGGATTCT");
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "disallow first strand longer" {
     const expected = DNAError.UnequalDNAStrands;
     const actual = comptime hamming.compute("AATG", "AAA");
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "disallow second strand longer" {
     const expected = DNAError.UnequalDNAStrands;
     const actual = comptime hamming.compute("ATA", "AGTG");
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "disallow left empty strand" {
     const expected = DNAError.EmptyDNAStrands;
     const actual = comptime hamming.compute("", "G");
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 test "disallow right empty strand" {
     const expected = DNAError.EmptyDNAStrands;
     const actual = comptime hamming.compute("G", "");
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }

--- a/exercises/practice/hello-world/test_hello_world.zig
+++ b/exercises/practice/hello-world/test_hello_world.zig
@@ -6,5 +6,5 @@ const hello_world = @import("hello_world.zig");
 test "say hi" {
     const expected = "Hello, world!";
     const actual = comptime hello_world.hello();
-    comptime testing.expectEqualStrings(expected, actual);
+    comptime try testing.expectEqualStrings(expected, actual);
 }

--- a/exercises/practice/isogram/test_isogram.zig
+++ b/exercises/practice/isogram/test_isogram.zig
@@ -4,53 +4,53 @@ const testing = std.testing;
 const isogram = @import("isogram.zig");
 
 test "empty string" {
-    testing.expect(isogram.isIsogram(""));
+    try testing.expect(isogram.isIsogram(""));
 }
 
 test "isogram with only lower case characters" {
-    testing.expect(isogram.isIsogram("isogram"));
+    try testing.expect(isogram.isIsogram("isogram"));
 }
 
 test "word with one duplicated character" {
-    testing.expect(!isogram.isIsogram("eleven"));
+    try testing.expect(!isogram.isIsogram("eleven"));
 }
 
 test "word with one duplicated character from the end of the alphabet" {
-    testing.expect(!isogram.isIsogram("zzyzx"));
+    try testing.expect(!isogram.isIsogram("zzyzx"));
 }
 
 test "word with one duplicated character from the end of the alphabet" {
-    testing.expect(isogram.isIsogram("subdermatoglyphic"));
+    try testing.expect(isogram.isIsogram("subdermatoglyphic"));
 }
 
 test "word with duplicated character in mixed case" {
-    testing.expect(!isogram.isIsogram("Alphabet"));
+    try testing.expect(!isogram.isIsogram("Alphabet"));
 }
 
 test "word with duplicated character in mixed case, lowercase first" {
-    testing.expect(!isogram.isIsogram("alphAbet"));
+    try testing.expect(!isogram.isIsogram("alphAbet"));
 }
 
 test "hypothetical isogrammic word with hyphen" {
-    testing.expect(isogram.isIsogram("thumbscrew-japingly"));
+    try testing.expect(isogram.isIsogram("thumbscrew-japingly"));
 }
 
 test "hypothetical word with duplicated character following hyphen" {
-    testing.expect(!isogram.isIsogram("thumbscrew-jappingly"));
+    try testing.expect(!isogram.isIsogram("thumbscrew-jappingly"));
 }
 
 test "isogram with duplicated hyphen" {
-    testing.expect(isogram.isIsogram("six-year-old"));
+    try testing.expect(isogram.isIsogram("six-year-old"));
 }
 
 test "made-up name that is an isogram" {
-    testing.expect(isogram.isIsogram("Emily Jung Schwartzkopf"));
+    try testing.expect(isogram.isIsogram("Emily Jung Schwartzkopf"));
 }
 
 test "duplicated character in the middle" {
-    testing.expect(!isogram.isIsogram("accentor"));
+    try testing.expect(!isogram.isIsogram("accentor"));
 }
 
 test "same first and last characters" {
-    testing.expect(!isogram.isIsogram("angola"));
+    try testing.expect(!isogram.isIsogram("angola"));
 }

--- a/exercises/practice/leap/test_leap.zig
+++ b/exercises/practice/leap/test_leap.zig
@@ -4,37 +4,37 @@ const testing = std.testing;
 const leap = @import("leap.zig");
 
 test "year not divisible by 4 in common year" {
-    comptime testing.expect(!leap.leap(2015));
+    comptime try testing.expect(!leap.leap(2015));
 }
 
 test "year divisible by 2, not divisible by 4 in common year" {
-    comptime testing.expect(!leap.leap(1970));
+    comptime try testing.expect(!leap.leap(1970));
 }
 
 test "year divisible by 4, not divisible by 100 in leap year" {
-    comptime testing.expect(leap.leap(1996));
+    comptime try testing.expect(leap.leap(1996));
 }
 
 test "year divisible by 4 and 5 is still a leap year" {
-    comptime testing.expect(leap.leap(1960));
+    comptime try testing.expect(leap.leap(1960));
 }
 
 test "year divisible by 100, not divisible by 400 in common year" {
-    comptime testing.expect(!leap.leap(2100));
+    comptime try testing.expect(!leap.leap(2100));
 }
 
 test "year divisible by 100 but not by 3 is still not a leap year" {
-    comptime testing.expect(!leap.leap(1900));
+    comptime try testing.expect(!leap.leap(1900));
 }
 
 test "year divisible by 400 is leap year" {
-    comptime testing.expect(leap.leap(2000));
+    comptime try testing.expect(leap.leap(2000));
 }
 
 test "year divisible by 400 but not by 125 is still a leap year" {
-    comptime testing.expect(leap.leap(2400));
+    comptime try testing.expect(leap.leap(2400));
 }
 
 test "year divisible by 200, not divisible by 400 in common year" {
-    comptime testing.expect(!leap.leap(1800));
+    comptime try testing.expect(!leap.leap(1800));
 }

--- a/exercises/practice/pangram/test_pangram.zig
+++ b/exercises/practice/pangram/test_pangram.zig
@@ -4,50 +4,50 @@ const testing = std.testing;
 const pangram = @import("pangram.zig");
 
 test "empty sentence" {
-    comptime testing.expect(!pangram.isPangram(""));
+    comptime try testing.expect(!pangram.isPangram(""));
 }
 
 test "perfect lower case" {
-    comptime testing.expect(
+    comptime try testing.expect(
         pangram.isPangram("abcdefghijklmnopqrstuvwxyz"));
 }
 
 test "only lower case" {
-    comptime testing.expect(pangram.isPangram(
+    comptime try testing.expect(pangram.isPangram(
         "the quick brown fox jumps over the lazy dog"));
 }
 
 test "missing letter x" {
-    comptime testing.expect(!pangram.isPangram(
+    comptime try testing.expect(!pangram.isPangram(
         "a quick movement of the enemy will jeopardize five gunboats"));
 }
 
 test "missing letter h" {
-    comptime testing.expect(!pangram.isPangram(
+    comptime try testing.expect(!pangram.isPangram(
         "five boxing wizards jump quickly at it"));
 }
 
 test "with underscores" {
-    comptime testing.expect(pangram.isPangram(
+    comptime try testing.expect(pangram.isPangram(
         "the_quick_brown_fox_jumps_over_the_lazy_dog"));
 }
 
 test "with numbers" {
-    comptime testing.expect(pangram.isPangram(
+    comptime try testing.expect(pangram.isPangram(
         "the 1 quick brown fox jumps over the 2 lazy dogs"));
 }
 
 test "missing letters replaced by numbers" {
-    comptime testing.expect(!pangram.isPangram(
+    comptime try testing.expect(!pangram.isPangram(
         "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"));
 }
 
 test "missing letters replaced by numbers" {
-    comptime testing.expect(pangram.isPangram(
+    comptime try testing.expect(pangram.isPangram(
         "\"Five quacking Zephyrs jolt my wax bed.\""));
 }
 
 test "case insensitive" {
-    comptime testing.expect(!pangram.isPangram(
+    comptime try testing.expect(!pangram.isPangram(
         "the quick brown fox jumps over with lazy FX"));
 }

--- a/exercises/practice/proverb/test_proverb.zig
+++ b/exercises/practice/proverb/test_proverb.zig
@@ -11,7 +11,7 @@ test "zero pieces" {
 
     const actual = try proverb.recite(testing.allocator, input_slice);
 
-    testing.expectEqualSlices([]const u8, expected, actual);
+    try testing.expectEqualSlices([]const u8, expected, actual);
 
     // The free here doesn't actually free memory since a zero sized heap
     // allocation doesn't actually point to anything important. So the free
@@ -34,7 +34,7 @@ test "one piece" {
     const actual = try proverb.recite(testing.allocator, input_slice);
 
     for (expected) |expected_slice, i| {
-        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+        try testing.expectEqualSlices(u8, expected_slice, actual[i]);
     }
 
     for (actual) |inner_slice| {
@@ -62,7 +62,7 @@ test "two pieces" {
     const actual = try proverb.recite(testing.allocator, input_slice);
 
     for (expected) |expected_slice, i| {
-        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+        try testing.expectEqualSlices(u8, expected_slice, actual[i]);
     }
 
     for (actual) |inner_slice| {
@@ -95,7 +95,7 @@ test "three pieces" {
     const actual = try proverb.recite(testing.allocator, input_slice);
 
     for (expected) |expected_slice, i| {
-        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+        try testing.expectEqualSlices(u8, expected_slice, actual[i]);
     }
 
     for (actual) |inner_slice| {
@@ -145,7 +145,7 @@ test "full proverb" {
     const actual = try proverb.recite(testing.allocator, input_slice);
 
     for (expected) |expected_slice, i| {
-        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+        try testing.expectEqualSlices(u8, expected_slice, actual[i]);
     }
 
     for (actual) |inner_slice| {
@@ -182,7 +182,7 @@ test "four pieces modernized" {
     const actual = try proverb.recite(testing.allocator, input_slice);
 
     for (expected) |expected_slice, i| {
-        testing.expectEqualSlices(u8, expected_slice, actual[i]);
+        try testing.expectEqualSlices(u8, expected_slice, actual[i]);
     }
 
     for (actual) |inner_slice| {

--- a/exercises/practice/queen-attack/test_queen_attack.zig
+++ b/exercises/practice/queen-attack/test_queen_attack.zig
@@ -6,68 +6,68 @@ const QueenError = queen_attack.QueenError;
 
 test "queen with a valid position" {
     const queen = try queen_attack.Queen.init(2, 2);
-    testing.expectEqual(
+    try testing.expectEqual(
         @as(queen_attack.Queen, .{.x = 2, .y = 2}), queen);
 }
 
 test "queen must have positive row" {
     const queen = queen_attack.Queen.init(-2, 2);
-    testing.expectError(QueenError.InitializationFailure, queen);
+    try testing.expectError(QueenError.InitializationFailure, queen);
 }
 
 test "queen must have row on board" {
     const queen = queen_attack.Queen.init(8, 4);
-    testing.expectError(QueenError.InitializationFailure, queen);
+    try testing.expectError(QueenError.InitializationFailure, queen);
 }
 
 test "queen must have positive column" {
     const queen = queen_attack.Queen.init(2, -2);
-    testing.expectError(QueenError.InitializationFailure, queen);
+    try testing.expectError(QueenError.InitializationFailure, queen);
 }
 
 test "queen must have column on board" {
     const queen = queen_attack.Queen.init(4, 8);
-    testing.expectError(QueenError.InitializationFailure, queen);
+    try testing.expectError(QueenError.InitializationFailure, queen);
 }
 
 test "cannot attack" {
     const white = try queen_attack.Queen.init(2, 4);
     const black = try queen_attack.Queen.init(6, 6);
-    testing.expect(!try white.canAttack(black));
+    try testing.expect(!try white.canAttack(black));
 }
 
 test "can attack on same row" {
     const white = try queen_attack.Queen.init(2, 4);
     const black = try queen_attack.Queen.init(2, 6);
-    testing.expect(try white.canAttack(black));
+    try testing.expect(try white.canAttack(black));
 }
 
 test "can attack on same column" {
     const white = try queen_attack.Queen.init(4, 5);
     const black = try queen_attack.Queen.init(2, 5);
-    testing.expect(try white.canAttack(black));
+    try testing.expect(try white.canAttack(black));
 }
 
 test "can attack on first diagonal" {
     const white = try queen_attack.Queen.init(2, 2);
     const black = try queen_attack.Queen.init(0, 4);
-    testing.expect(try white.canAttack(black));
+    try testing.expect(try white.canAttack(black));
 }
 
 test "can attack on second diagonal" {
     const white = try queen_attack.Queen.init(2, 2);
     const black = try queen_attack.Queen.init(3, 1);
-    testing.expect(try white.canAttack(black));
+    try testing.expect(try white.canAttack(black));
 }
 
 test "can attack on third diagonal" {
     const white = try queen_attack.Queen.init(2, 2);
     const black = try queen_attack.Queen.init(1, 1);
-    testing.expect(try white.canAttack(black));
+    try testing.expect(try white.canAttack(black));
 }
 
 test "can attack on fourth diagonal" {
     const white = try queen_attack.Queen.init(1, 7);
     const black = try queen_attack.Queen.init(0, 6);
-    testing.expect(try white.canAttack(black));
+    try testing.expect(try white.canAttack(black));
 }

--- a/exercises/practice/resistor-color-duo/test_resistor_color_duo.zig
+++ b/exercises/practice/resistor-color-duo/test_resistor_color_duo.zig
@@ -8,33 +8,33 @@ test "brown and black" {
     const array = [_]ColorBand{.brown, .black};
     const expected = 10;
     const actual = comptime try resistor_color_duo.color_code(&array);
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "blue and grey" {
     const array = [_]ColorBand{.blue, .grey};
     const expected = 68;
     const actual = comptime try resistor_color_duo.color_code(&array);
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "yellow and violet" {
     const array = [_]ColorBand{.yellow, .violet};
     const expected = 47;
     const actual = comptime try resistor_color_duo.color_code(&array);
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "orange and orange" {
     const array = [_]ColorBand{.orange, .orange};
     const expected = 33;
     const actual = comptime try resistor_color_duo.color_code(&array);
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }
 
 test "ignore additional colors" {
     const array = [_]ColorBand{.green, .brown, .orange};
     const expected = 51;
     const actual = comptime try resistor_color_duo.color_code(&array);
-    testing.expectEqual(expected, actual);
+    try testing.expectEqual(expected, actual);
 }

--- a/exercises/practice/resistor-color/test_resistor_color.zig
+++ b/exercises/practice/resistor-color/test_resistor_color.zig
@@ -7,19 +7,19 @@ const ColorBand = resistor_color.ColorBand;
 test "test black" {
     const expected = 0;
     const actual = comptime resistor_color.color_code(.black);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "test white" {
     const expected = 9;
     const actual = comptime resistor_color.color_code(.white);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "test orange" {
     const expected = 3;
     const actual = comptime resistor_color.color_code(.orange);
-    comptime testing.expectEqual(expected, actual);
+    comptime try testing.expectEqual(expected, actual);
 }
 
 test "test colors" {
@@ -28,5 +28,5 @@ test "test colors" {
         .green, .blue, .violet, .grey, .white,
     };
     const actual = comptime resistor_color.colors();
-    comptime testing.expectEqualSlices(ColorBand, expected, actual);
+    comptime try testing.expectEqualSlices(ColorBand, expected, actual);
 }

--- a/exercises/practice/rna-transcription/.meta/example.zig
+++ b/exercises/practice/rna-transcription/.meta/example.zig
@@ -8,7 +8,7 @@ pub const RNAError = error {
 pub fn toRna(
     allocator: *mem.Allocator,
     dna: []const u8
-) (RNAError || mem.Allocator.Error)![]const u8 {
+) ![]const u8 {
     var rna_slice = try allocator.alloc(u8, dna.len);
     for (dna) |dna_nucleotide, i| {
         switch (dna_nucleotide) {

--- a/exercises/practice/rna-transcription/test_rna_transcription.zig
+++ b/exercises/practice/rna-transcription/test_rna_transcription.zig
@@ -10,7 +10,7 @@ fn test_transcription(
     expected: []const u8
 ) (rna_transcription.RNAError || mem.Allocator.Error)!void {
     const rna = try rna_transcription.toRna(testing.allocator, dna);
-    testing.expectEqualStrings(expected, rna);
+    try testing.expectEqualStrings(expected, rna);
     testing.allocator.free(rna);
 }
 
@@ -19,7 +19,7 @@ fn test_failure(
 ) (rna_transcription.RNAError || mem.Allocator.Error)!void {
     const expected = RNAError.IllegalDNANucleotide;
     const actual = rna_transcription.toRna(testing.allocator, dna);
-    testing.expectError(expected, actual);
+    try testing.expectError(expected, actual);
 }
 
 

--- a/exercises/practice/rna-transcription/test_rna_transcription.zig
+++ b/exercises/practice/rna-transcription/test_rna_transcription.zig
@@ -8,7 +8,7 @@ const RNAError = rna_transcription.RNAError;
 fn test_transcription(
     dna: []const u8,
     expected: []const u8
-) (rna_transcription.RNAError || mem.Allocator.Error)!void {
+) !void {
     const rna = try rna_transcription.toRna(testing.allocator, dna);
     try testing.expectEqualStrings(expected, rna);
     testing.allocator.free(rna);
@@ -16,7 +16,7 @@ fn test_transcription(
 
 fn test_failure(
     dna: []const u8
-) (rna_transcription.RNAError || mem.Allocator.Error)!void {
+) !void {
     const expected = RNAError.IllegalDNANucleotide;
     const actual = rna_transcription.toRna(testing.allocator, dna);
     try testing.expectError(expected, actual);

--- a/exercises/practice/secret-handshake/test_secret_handshake.zig
+++ b/exercises/practice/secret-handshake/test_secret_handshake.zig
@@ -7,56 +7,56 @@ test "wink for 1" {
     const expected = &[_]secret_handshake.Signal{.wink};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 1);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "double blink for 10" {
     const expected = &[_]secret_handshake.Signal{.double_blink};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 2);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "close your eyes for 100" {
     const expected = &[_]secret_handshake.Signal{.close_your_eyes};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 4);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "jump for 1000" {
     const expected = &[_]secret_handshake.Signal{.jump};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 8);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "combine two actions" {
     const expected = &[_]secret_handshake.Signal{.wink, .double_blink};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 3);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "reverse two actions" {
     const expected = &[_]secret_handshake.Signal{.double_blink, .wink};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 19);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "reversing one action gives the same action" {
     const expected = &[_]secret_handshake.Signal{.jump};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 24);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "reversing no actions still gives no actions" {
     const expected = &[_]secret_handshake.Signal{};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 16);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "all possible actions" {
@@ -64,7 +64,7 @@ test "all possible actions" {
         .wink, .double_blink, .close_your_eyes, .jump};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 15);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "reverse all possible actions" {
@@ -72,12 +72,12 @@ test "reverse all possible actions" {
         .jump, .close_your_eyes, .double_blink, .wink};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 31);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }
 
 test "do nothing for zero" {
     const expected = &[_]secret_handshake.Signal{};
     var actual = try secret_handshake.calculateHandshake(testing.allocator, 0);
     defer testing.allocator.free(actual);
-    testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
+    try testing.expectEqualSlices(secret_handshake.Signal, expected, actual);
 }

--- a/exercises/practice/space-age/test_space_age.zig
+++ b/exercises/practice/space-age/test_space_age.zig
@@ -7,54 +7,54 @@ test "age on earth" {
     const sp = comptime space_age.SpaceAge.init(1000000000);
     const expected = 31.69;
     const actual = comptime sp.onEarth();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on mercury" {
     const sp = comptime space_age.SpaceAge.init(2134835688);
     const expected = 280.88;
     const actual = comptime sp.onMercury();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on venus" {
     const sp = comptime space_age.SpaceAge.init(189839836);
     const expected = 9.78;
     const actual = comptime sp.onVenus();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on mars" {
     const sp = comptime space_age.SpaceAge.init(2129871239);
     const expected = 35.88;
     const actual = comptime sp.onMars();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on jupiter" {
     const sp = comptime space_age.SpaceAge.init(901876382);
     const expected = 2.41;
     const actual = comptime sp.onJupiter();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on saturn" {
     const sp = comptime space_age.SpaceAge.init(2000000000);
     const expected = 2.15;
     const actual = comptime sp.onSaturn();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on uranus" {
     const sp = comptime space_age.SpaceAge.init(1210123456);
     const expected = 0.46;
     const actual = comptime sp.onUranus();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }
 
 test "age on neptune" {
     const sp = comptime space_age.SpaceAge.init(1821023456);
     const expected = 0.35;
     const actual = comptime sp.onNeptune();
-    comptime testing.expectWithinMargin(expected, actual, 1.0);
+    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
 }

--- a/exercises/practice/triangle/test_triangle.zig
+++ b/exercises/practice/triangle/test_triangle.zig
@@ -5,100 +5,100 @@ const triangle = @import("triangle.zig");
 
 test "equilateral all sides are equal" {
     const actual = comptime try triangle.Triangle.init(2, 2, 2);
-    comptime testing.expect(actual.isEquilateral());
+    comptime try testing.expect(actual.isEquilateral());
 }
 
 test "equilateral any side is unequal" {
     const actual = comptime try triangle.Triangle.init(2, 3, 2);
-    comptime testing.expect(!actual.isEquilateral());
+    comptime try testing.expect(!actual.isEquilateral());
 }
 
 test "equilateral no sides are equal" {
     const actual = comptime try triangle.Triangle.init(5, 4, 6);
-    comptime testing.expect(!actual.isEquilateral());
+    comptime try testing.expect(!actual.isEquilateral());
 }
 
 test "equilateral all zero sies is not a triangle" {
     const actual = triangle.Triangle.init(0, 0, 0);
-    testing.expectError(triangle.TriangleError.Degenerate, actual);
+    try testing.expectError(triangle.TriangleError.Degenerate, actual);
 }
 
 test "equilateral sides may be floats" {
     const actual = comptime try triangle.Triangle.init(0.5, 0.5, 0.5);
-    comptime testing.expect(actual.isEquilateral());
+    comptime try testing.expect(actual.isEquilateral());
 }
 
 test "isosceles last two sides are equal" {
     const actual = comptime try triangle.Triangle.init(3, 4, 4);
-    comptime testing.expect(actual.isIsosceles());
+    comptime try testing.expect(actual.isIsosceles());
 }
 
 test "isosceles first two sides are equal" {
     const actual = comptime try triangle.Triangle.init(4, 4, 3);
-    comptime testing.expect(actual.isIsosceles());
+    comptime try testing.expect(actual.isIsosceles());
 }
 
 test "isosceles first and last sides are equal" {
     const actual = comptime try triangle.Triangle.init(4, 3, 4);
-    comptime testing.expect(actual.isIsosceles());
+    comptime try testing.expect(actual.isIsosceles());
 }
 
 test "equilateral triangles are also isosceles" {
     const actual = comptime try triangle.Triangle.init(4, 3, 4);
-    comptime testing.expect(actual.isIsosceles());
+    comptime try testing.expect(actual.isIsosceles());
 }
 
 test "isosceles no sides are equal" {
     const actual = comptime try triangle.Triangle.init(2, 3, 4);
-    comptime testing.expect(!actual.isIsosceles());
+    comptime try testing.expect(!actual.isIsosceles());
 }
 
 test "isosceles first triangle inequality violation" {
     const actual = triangle.Triangle.init(1, 1, 3);
-    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
 }
 
 test "isosceles second triangle inequality violation" {
     const actual = triangle.Triangle.init(1, 3, 1);
-    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
 }
 
 test "isosceles third triangle inequality violation" {
     const actual = triangle.Triangle.init(3, 1, 1);
-    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
 }
 
 test "isosceles sides may be floats" {
     const actual = comptime try triangle.Triangle.init(0.5, 0.4, 0.5);
-    comptime testing.expect(actual.isIsosceles());
+    comptime try testing.expect(actual.isIsosceles());
 }
 
 test "scalene no sides are equal" {
     const actual = comptime try triangle.Triangle.init(5, 4, 6);
-    comptime testing.expect(actual.isScalene());
+    comptime try testing.expect(actual.isScalene());
 }
 
 test "scalene all sides are equal" {
     const actual = comptime try triangle.Triangle.init(4, 4, 4);
-    comptime testing.expect(!actual.isScalene());
+    comptime try testing.expect(!actual.isScalene());
 }
 
 test "scalene two sides are equal" {
     const actual = comptime try triangle.Triangle.init(4, 4, 3);
-    comptime testing.expect(!actual.isScalene());
+    comptime try testing.expect(!actual.isScalene());
 }
 
 test "scalene two sides are equal" {
     const actual = comptime try triangle.Triangle.init(4, 4, 3);
-    comptime testing.expect(!actual.isScalene());
+    comptime try testing.expect(!actual.isScalene());
 }
 
 test "scalene may not violate triangle inequality" {
     const actual = triangle.Triangle.init(7, 3, 2);
-    testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
 }
 
 test "scalene sides may be floats" {
     const actual = comptime try triangle.Triangle.init(0.5, 0.4, 0.6);
-    comptime testing.expect(actual.isScalene());
+    comptime try testing.expect(actual.isScalene());
 }

--- a/exercises/practice/two-fer/.meta/example.zig
+++ b/exercises/practice/two-fer/.meta/example.zig
@@ -3,6 +3,6 @@ const fmt = std.fmt;
 
 pub fn two_fer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
     var word = if (name == null) "me" else name;
-    var slice = try fmt.bufPrint(buffer, "One for {}, one for you.", .{word});
+    var slice = try fmt.bufPrint(buffer, "One for {s}, one for you.", .{word});
     return slice;
 }

--- a/exercises/practice/two-fer/test_two_fer.zig
+++ b/exercises/practice/two-fer/test_two_fer.zig
@@ -9,19 +9,19 @@ test "no name given" {
     var response: [BUFFER_SIZE]u8 = undefined;
     const expected = "One for me, one for you.";
     const actual = try two_fer.two_fer(&response, null);
-    testing.expectEqualStrings(expected, actual);
+    try testing.expectEqualStrings(expected, actual);
 }
 
 test "a name given" {
     var response: [BUFFER_SIZE]u8 = undefined;
     const expected = "One for Alice, one for you.";
     const actual = try two_fer.two_fer(&response, "Alice");
-    testing.expectEqualStrings(expected, actual);
+    try testing.expectEqualStrings(expected, actual);
 }
 
 test "another name given" {
     var response: [BUFFER_SIZE]u8 = undefined;
     const expected = "One for Bob, one for you.";
     const actual = try two_fer.two_fer(&response, "Bob");
-    testing.expectEqualStrings(expected, actual);
+    try testing.expectEqualStrings(expected, actual);
 }


### PR DESCRIPTION
- try seems required before testing operations now
- use newer API expectApproxEqRel

All tests run now on 0.8.1 other than `space-age`.  Could use help there.

---

This fixes all tests (on 0.8.1) other than `space-age`.

```
/usr/local/Cellar/zig/0.8.1/lib/zig/std/testing.zig:264:27: error: Cannot approximately compare two comptime_float values
        .ComptimeFloat => @compileError("Cannot approximately compare two comptime_float values"),
```

I did correct to the new API, but there still seems to be another issue.

