### PR TITLE
docs: add shared docs

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,0 +1,16 @@
+# Help
+
+- [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
+- [Zig Learn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
+- [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord]. It provides a great way to get in touch with the Zig community at large, and get some quick, direct help for any Zig related problem.
+- [#zig][irc] on irc.freenode.net is the main Zig IRC channel.
+- [/r/Zig][reddit] is the main Zig subreddit.
+- [Stack Overflow][stack-overflow] can be used to discover code snippets and solutions to problems that may have already asked and maybe solved by others.
+
+[discord]: https://discordapp.com
+[discord-zig]: https://discord.com/invite/gxsFFjE
+[documentation]: https://ziglang.org/documentation/master
+[irc]: https://webchat.freenode.net/?channels=%23zig
+[reddit]: https://www.reddit.com/r/Zig
+[stack-overflow]: https://stackoverflow.com/questions/tagged/zig
+[zig-learn]: https://ziglearn.org/

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,0 +1,11 @@
+# Running tests
+
+Write your code in `<exercise_name>.zig`.
+
+To run the tests for an exercise, run:
+
+```bash
+zig test test_exercise_name.zig
+```
+
+in the exercise's root directory (replacing `exercise_name` with the name of the exercise).


### PR DESCRIPTION
This commit resolves an error from `configlet lint`.

From the Exercism [docs](https://exercism.org/docs/building/tracks/shared-files) on these so-called "shared files":

> - help.md: contains track-specific instructions on how to get help (required)
> - tests.md: contains track-specific instructions on how to run the tests (required)
