### PR TITLE
install-zig, exercises: bump Zig from 0.8.1 to 0.9.1

### DIFF
--- a/.github/bin/install-zig.sh
+++ b/.github/bin/install-zig.sh
@@ -16,7 +16,7 @@ esac
 
 arch="$(uname -m)"
 
-version='0.8.1'
+version='0.9.1'
 url="https://ziglang.org/download/${version}/zig-${os}-${arch}-${version}.${ext}"
 
 curlopts=(

--- a/exercises/practice/proverb/.meta/example.zig
+++ b/exercises/practice/proverb/.meta/example.zig
@@ -3,7 +3,7 @@ const fmt = std.fmt;
 const mem = std.mem;
 
 pub fn recite(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     words: []const []const u8
 ) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
 

--- a/exercises/practice/proverb/proverb.zig
+++ b/exercises/practice/proverb/proverb.zig
@@ -1,5 +1,5 @@
 pub fn recite(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     words: []const []const u8
 ) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
     @panic("please implement the recite function");

--- a/exercises/practice/rna-transcription/.meta/example.zig
+++ b/exercises/practice/rna-transcription/.meta/example.zig
@@ -6,7 +6,7 @@ pub const RNAError = error {
 };
 
 pub fn toRna(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     dna: []const u8
 ) ![]const u8 {
     var rna_slice = try allocator.alloc(u8, dna.len);

--- a/exercises/practice/rna-transcription/rna_transcription.zig
+++ b/exercises/practice/rna-transcription/rna_transcription.zig
@@ -1,7 +1,7 @@
 // Import the appropriate standard library and modules
 
 pub fn toRna(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     dna: []const u8
 ) (RNAError || mem.Allocator.Error)![]const u8 {
     @panic("please implement the toRna function");

--- a/exercises/practice/secret-handshake/.meta/example.zig
+++ b/exercises/practice/secret-handshake/.meta/example.zig
@@ -9,7 +9,7 @@ pub const Signal = enum(u2) {
 };
 
 pub fn calculateHandshake(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     number: isize
 ) mem.Allocator.Error![]const Signal {
     var list = std.ArrayList(Signal).init(allocator);

--- a/exercises/practice/secret-handshake/secret_handshake.zig
+++ b/exercises/practice/secret-handshake/secret_handshake.zig
@@ -1,5 +1,5 @@
 pub fn calculateHandshake(
-    allocator: *mem.Allocator,
+    allocator: mem.Allocator,
     number: isize
 ) mem.Allocator.Error![]const Signal {
     @panic("please implement the calculateHandshake function");


### PR DESCRIPTION
See the release notes for Zig [0.9.0][1] and [0.9.1][2].

Upgrading Zig produced errors like:

```text
./test_proverb.zig:12:46: error: expected type '*std.mem.Allocator', found 'std.mem.Allocator'
    const actual = try proverb.recite(testing.allocator, input_slice);
                                                 ^
/foo/zig-linux-x86_64-0.9.1/lib/std/mem/Allocator.zig:1:1: note: std.mem.Allocator declared here
//! The standard memory allocation interface.
^
```

So this PR must also fix the errors by following the advice from the [Zig 0.9.0 release notes][3]:

>The `mem.Allocator` interface has changed in a breaking way.
>
>In short summary, here is how to change your code:
>
>- Change `*Allocator` to `Allocator` in function parameter types and struct field types.
>
>- Instead of taking the pointer to an allocator field, such as `&gpa.allocator`, use a function call like this: `gpa.allocator()`.

For more details, see the blog post on [Allocgate][4].

[1]: https://ziglang.org/download/0.9.0/release-notes.html
[2]: https://ziglang.org/download/0.9.1/release-notes.html
[3]: https://ziglang.org/download/0.9.0/release-notes.html#Allocgate
[4]: https://pithlessly.github.io/allocgate.html

Refs: #99



---

To-do:

- [x] Merge #105
- [x] Merge #100
- [x] Merge #102 
- [x] Fix tests for `proverb`, `rna-transcription`, `secret-handshake`

Zig is ~getting pretty close to~ has released 0.10.0 (see https://github.com/ziglang/zig/milestone/16), but let's handle that bump in a separate PR. Probably more breakage.