### PR TITLE
ci: bump Zig from 0.7.0 to 0.8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install Zig
       run: |
-        curl -o zig.tar.xz https://ziglang.org/download/0.7.0/zig-linux-x86_64-0.7.0.tar.xz
+        curl -o zig.tar.xz https://ziglang.org/download/0.8.1/zig-linux-x86_64-0.8.1.tar.xz
         tar xJf zig.tar.xz
         mkdir -p $HOME/bin
         ln -s $(pwd)/zig-*/zig $HOME/bin
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install Zig
       run: |
-        curl -o zig.tar.xz https://ziglang.org/download/0.7.0/zig-macos-x86_64-0.7.0.tar.xz
+        curl -o zig.tar.xz https://ziglang.org/download/0.8.1/zig-macos-x86_64-0.8.1.tar.xz
         tar xJf zig.tar.xz
         mkdir -p $HOME/bin
         ln -s $(pwd)/zig-*/zig $HOME/bin


### PR DESCRIPTION
Looks like it's best to do this before bumping to 0.9.1.

Related: #104
Related: #99

This makes a bunch of exercise tests pass, but not those for `space-age`.