### PR TITLE
exercises: space-age: fix compilation errors

### DIFF
--- a/exercises/practice/space-age/test_space_age.zig
+++ b/exercises/practice/space-age/test_space_age.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const testing = std.testing;
+const expect = std.testing.expect;
+const approxEqRel = std.math.approxEqRel;
 
 const space_age = @import("space_age.zig");
 
@@ -7,54 +8,54 @@ test "age on earth" {
     const sp = comptime space_age.SpaceAge.init(1000000000);
     const expected = 31.69;
     const actual = comptime sp.onEarth();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on mercury" {
     const sp = comptime space_age.SpaceAge.init(2134835688);
     const expected = 280.88;
     const actual = comptime sp.onMercury();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on venus" {
     const sp = comptime space_age.SpaceAge.init(189839836);
     const expected = 9.78;
     const actual = comptime sp.onVenus();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on mars" {
     const sp = comptime space_age.SpaceAge.init(2129871239);
     const expected = 35.88;
     const actual = comptime sp.onMars();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on jupiter" {
     const sp = comptime space_age.SpaceAge.init(901876382);
     const expected = 2.41;
     const actual = comptime sp.onJupiter();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on saturn" {
     const sp = comptime space_age.SpaceAge.init(2000000000);
     const expected = 2.15;
     const actual = comptime sp.onSaturn();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on uranus" {
     const sp = comptime space_age.SpaceAge.init(1210123456);
     const expected = 0.46;
     const actual = comptime sp.onUranus();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }
 
 test "age on neptune" {
     const sp = comptime space_age.SpaceAge.init(1821023456);
     const expected = 0.35;
     const actual = comptime sp.onNeptune();
-    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
+    comptime try expect(approxEqRel(f64, expected, actual, 1.0));
 }


### PR DESCRIPTION

This may not be the best fix. But, along with the update to Zig 0.8.1,
these changes do at least make the tests pass for every exercise.

Before this commit:

```console
$ zig test test_space_age.zig
/usr/lib/zig/std/testing.zig:263:27: error: Cannot approximately compare two comptime_float values
        .ComptimeFloat => @compileError("Cannot approximately compare two comptime_float values"),
                          ^
./exercises/practice/space-age/test_space_age.zig:10:43: note: called from here
    comptime try testing.expectApproxEqRel(expected, actual, 1.0);
                                          ^
./exercises/practice/space-age/test_space_age.zig:6:21: note: called from here
test "age on earth" {
                    ^
```

With this commit:

```console
$ zig test test_space_age.zig
All 8 tests passed.
```

Closes: #104
See also: https://github.com/exercism/zig/pull/91