### PR TITLE
install-zig, exercises: bump Zig from 0.9.1 to 0.10.1

### DIFF
--- a/.github/bin/install-zig.sh
+++ b/.github/bin/install-zig.sh
@@ -16,7 +16,7 @@ esac
 
 arch="$(uname -m)"
 
-version='0.9.1'
+version='0.10.1'
 url="https://ziglang.org/download/${version}/zig-${os}-${arch}-${version}.${ext}"
 
 curlopts=(

--- a/exercises/practice/leap/.meta/example.zig
+++ b/exercises/practice/leap/.meta/example.zig
@@ -1,11 +1,3 @@
 pub fn leap(year: u32) bool {
-    const has_factor = (struct {
-        const Self = @This();
-        y: u32,
-        fn has_factor(self: Self, factor: u32) bool {
-            return self.y % factor == 0;
-        }
-    }{ .y = year }).has_factor;
-
-    return has_factor(4) and (!has_factor(100) or has_factor(400));
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0);
 }

--- a/exercises/practice/two-fer/.meta/example.zig
+++ b/exercises/practice/two-fer/.meta/example.zig
@@ -3,6 +3,6 @@ const fmt = std.fmt;
 
 pub fn two_fer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
     var word = if (name == null) "me" else name;
-    var slice = try fmt.bufPrint(buffer, "One for {s}, one for you.", .{word});
+    var slice = try fmt.bufPrint(buffer, "One for {?s}, one for you.", .{word});
     return slice;
 }


### PR DESCRIPTION
See the release notes for Zig [0.10.0][1] and [0.10.1][2].

Zig 0.10.1 produced these errors for the previous example solutions for `leap` and `two-fer`:

```console
$ zig test test_leap.zig
leap.zig:8:21: error: no field named 'has_factor' in struct 'leap.leap__struct_1016'
    }{ .y = year }).has_factor;
                    ^~~~~~~~~~
leap.zig:2:25: note: struct declared here
    const has_factor = (struct {
                        ^~~~~~
test_leap.zig:7:43: note: called from here
    comptime try testing.expect(!leap.leap(2015));
                                 ~~~~~~~~~^~~~~~
```

```console
$ zig test -freference-trace test_two_fer.zig
/foo/zig-linux-x86_64-0.10.1/lib/std/fmt.zig:498:17: error: cannot format optional without a specifier (i.e. {?} or {any})
                @compileError("cannot format optional without a specifier (i.e. {?} or {any})");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    format__anon_3843: /foo/zig-linux-x86_64-0.10.1/lib/std/fmt.zig:183:13
    bufPrint__anon_1501: /foo/zig-linux-x86_64-0.10.1/lib/std/fmt.zig:1922:9
    two_fer: two_fer.zig:6:24
    test.another name given: test_two_fer.zig:25:31
```

[1]: https://ziglang.org/download/0.10.0/release-notes.html
[2]: https://ziglang.org/download/0.10.1/release-notes.html

Refs: #99

---

Before merging this PR, let's try to bump to 0.9.1 separately.

To-do:

- [x] Bump directly to 0.10.1 in this PR
- [x] Make tests pass for `leap` and `two-fer`
- [x] Merge #103 (then rebase this PR on `main`)