### PR TITLE
Revert change to rna-transcription config

### DIFF
--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [
     "massivelivefun"
   ],
@@ -7,17 +8,17 @@
     "iHiD"
   ],
   "files": {
+    "example": [
+      ".meta/example.zig"
+    ],
     "solution": [
       "rna_transcription.zig"
     ],
     "test": [
       "test_rna_transcription.zig"
-    ],
-    "example": [
-      ".meta/example.zig"
     ]
   },
-  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "source": "Hyperphysics",
-  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
+  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
+  "title": "RNA Transcription"
 }


### PR DESCRIPTION
Configlet fmt removed the title of the exercise.
This is a bug, and I will be submitting an issue to the configlet
repository to ensure that this doesn't happen again.

My apologies for the noise.
