### PR TITLE
exercises(hello-world): test: handle incorrect solution better

### DIFF
--- a/exercises/practice/hello-world/test_hello_world.zig
+++ b/exercises/practice/hello-world/test_hello_world.zig
@@ -6,5 +6,5 @@ const hello_world = @import("hello_world.zig");
 test "say hi" {
     const expected = "Hello, world!";
     const actual = comptime hello_world.hello();
-    comptime try testing.expectEqualStrings(expected, actual);
+    try testing.expectEqualStrings(expected, actual);
 }


### PR DESCRIPTION
I think the simplest thing for now is to just remove the `comptime`. There is no other `comptime` use of `expectEqualStrings` in this repo.

We could instead use `mem.eql` like this:

```diff
 const std = @import("std");
+const mem = std.mem;
 const testing = std.testing;

 const hello_world = @import("hello_world.zig");

 test "say hi" {
     const expected = "Hello, world!";
     const actual = comptime hello_world.hello();
-    comptime try testing.expectEqualStrings(expected, actual);
+    comptime try testing.expect(mem.eql(u8, expected, actual));
```

but then the test failure message is less useful:

```console
$ zig test test_hello_world.zig
Test [1/1] test.say hi... FAIL (TestUnexpectedResult)
/foo/exercism-tracks/zig/exercises/practice/hello-world/test_hello_world.zig:10:40: 0x20eee7 in test.say hi (test)
    comptime try testing.expect(mem.eql(u8, expected, actual));
                                           ^
0 passed; 0 skipped; 1 failed.
```

---

Before this commit, when testing an incorrect solution:

```console
$ zig test test_hello_world.zig
/foo/zig/lib/std/Thread.zig:741:30: error: unable to evaluate comptime expression
        return tls_thread_id orelse {
               ~~~~~~~~~~~~~~^~~~~~
/foo/zig/lib/std/Thread.zig:275:29: note: called from here
    return Impl.getCurrentId();
           ~~~~~~~~~~~~~~~~~^~
/foo/zig/lib/std/Thread/Mutex.zig:82:47: note: called from here
        const current_id = Thread.getCurrentId();
                           ~~~~~~~~~~~~~~~~~~~^~
/foo/zig/lib/std/Thread/Mutex.zig:46:19: note: called from here
    self.impl.lock();
    ~~~~~~~~~~~~~~^~
/foo/zig/lib/std/debug.zig:90:22: note: called from here
    stderr_mutex.lock();
    ~~~~~~~~~~~~~~~~~^~
/foo/zig/lib/std/testing.zig:611:14: note: called from here
        print("\n====== expected this output: =========\n", .{});
        ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_hello_world.zig:9:44: note: called from here
    comptime try testing.expectEqualStrings(expected, actual);
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

With this commit, we get a test failure message:

```console
$ zig test test_hello_world.zig
Test [1/1] test.say hi...
====== expected this output: =========
Hello, world!␃

======== instead found this: =========
Goodbye, Mars!␃

======================================
First difference occurs on line 1:
expected:
Hello, world!
^ ('\x48')
found:
Goodbye, Mars!
^ ('\x47')
Test [1/1] test.say hi... FAIL (TestExpectedEqual)
```

Closes: https://github.com/exercism/zig-test-runner/issues/21