### PR TITLE
.github: enable `configlet fmt` in CI

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -13,3 +13,5 @@ permissions:
 jobs:
   configlet:
     uses: exercism/github-actions/.github/workflows/configlet.yml@main
+    with:
+      fmt: true


### PR DESCRIPTION
From the [configlet workflow log for this PR](https://github.com/exercism/zig/actions/runs/4092066220/jobs/7056546121#step:5:5):

```text
Found 0 Concept Exercises and 19 Practice Exercises in /home/runner/work/zig/zig/config.json
Looking for exercises that lack a formatted '.meta/config.json' file...
Every exercise config is already formatted!
```