### PR TITLE
exercises: use camelCase for function names

### DIFF
--- a/exercises/practice/difference-of-squares/.meta/example.zig
+++ b/exercises/practice/difference-of-squares/.meta/example.zig
@@ -1,12 +1,12 @@
-pub fn square_of_sum(number: isize) isize {
+pub fn squareOfSum(number: isize) isize {
     var result = @divExact(number * (number + 1), 2);
     return result * result;
 }
 
-pub fn sum_of_squares(number: isize) isize {
+pub fn sumOfSquares(number: isize) isize {
     return @divExact(number * (number + 1) * (2 * number + 1), 6);
 }
 
-pub fn difference_of_squares(number: isize) isize {
-    return square_of_sum(number) - sum_of_squares(number);
+pub fn differenceOfSquares(number: isize) isize {
+    return squareOfSum(number) - sumOfSquares(number);
 }

--- a/exercises/practice/difference-of-squares/difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/difference_of_squares.zig
@@ -1,11 +1,11 @@
-pub fn square_of_sum(number: isize) isize {
+pub fn squareOfSum(number: isize) isize {
     @panic("compute the sum of i from 0 to n then square it");
 }
 
-pub fn sum_of_squares(number: isize) isize {
+pub fn sumOfSquares(number: isize) isize {
     @panic("compute the sum of i^2 from 0 to n");
 }
 
-pub fn difference_of_squares(number: isize) isize {
+pub fn differenceOfSquares(number: isize) isize {
     @panic("compute the difference between the square of sum and sum of squares");
 }

--- a/exercises/practice/difference-of-squares/test_difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/test_difference_of_squares.zig
@@ -5,54 +5,54 @@ const difference_of_squares = @import("difference_of_squares.zig");
 
 test "square of sum up to 1" {
     const expected = 1;
-    const actual = comptime difference_of_squares.square_of_sum(1);
+    const actual = comptime difference_of_squares.squareOfSum(1);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "square of sum up to 5" {
     const expected = 225;
-    const actual = comptime difference_of_squares.square_of_sum(5);
+    const actual = comptime difference_of_squares.squareOfSum(5);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "square of sum up to 100" {
     const expected = 25502500;
-    const actual = comptime difference_of_squares.square_of_sum(100);
+    const actual = comptime difference_of_squares.squareOfSum(100);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "sum of squares up to 1" {
     const expected = 1;
-    const actual = comptime difference_of_squares.sum_of_squares(1);
+    const actual = comptime difference_of_squares.sumOfSquares(1);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "sum of squares up to 5" {
     const expected = 55;
-    const actual = comptime difference_of_squares.sum_of_squares(5);
+    const actual = comptime difference_of_squares.sumOfSquares(5);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "sum of squares up to 100" {
     const expected = 338350;
-    const actual = comptime difference_of_squares.sum_of_squares(100);
+    const actual = comptime difference_of_squares.sumOfSquares(100);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "difference of squares up to 1" {
     const expected = 0;
-    const actual = comptime difference_of_squares.difference_of_squares(1);
+    const actual = comptime difference_of_squares.differenceOfSquares(1);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "difference of squares up to 5" {
     const expected = 170;
-    const actual = comptime difference_of_squares.difference_of_squares(5);
+    const actual = comptime difference_of_squares.differenceOfSquares(5);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "difference of squares up to 100" {
     const expected = 25164150;
-    const actual = comptime difference_of_squares.difference_of_squares(100);
+    const actual = comptime difference_of_squares.differenceOfSquares(100);
     comptime try testing.expectEqual(expected, actual);
 }

--- a/exercises/practice/resistor-color-duo/.meta/example.zig
+++ b/exercises/practice/resistor-color-duo/.meta/example.zig
@@ -15,7 +15,7 @@ pub const RuntimeError = error {
     IllegalArgument,
 };
 
-pub fn color_code(colors: []const ColorBand) RuntimeError!isize {
+pub fn colorCode(colors: []const ColorBand) RuntimeError!isize {
     if (colors.len < 2) {
         return RuntimeError.IllegalArgument;
     }

--- a/exercises/practice/resistor-color-duo/resistor_color_duo.zig
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo.zig
@@ -1,3 +1,3 @@
-pub fn color_code(colors: []const ColorBand) anyerror!isize {
+pub fn colorCode(colors: []const ColorBand) anyerror!isize {
     @panic("please implement the color_code function");
 }

--- a/exercises/practice/resistor-color-duo/test_resistor_color_duo.zig
+++ b/exercises/practice/resistor-color-duo/test_resistor_color_duo.zig
@@ -7,34 +7,34 @@ const ColorBand = resistor_color_duo.ColorBand;
 test "brown and black" {
     const array = [_]ColorBand{.brown, .black};
     const expected = 10;
-    const actual = comptime try resistor_color_duo.color_code(&array);
+    const actual = comptime try resistor_color_duo.colorCode(&array);
     try testing.expectEqual(expected, actual);
 }
 
 test "blue and grey" {
     const array = [_]ColorBand{.blue, .grey};
     const expected = 68;
-    const actual = comptime try resistor_color_duo.color_code(&array);
+    const actual = comptime try resistor_color_duo.colorCode(&array);
     try testing.expectEqual(expected, actual);
 }
 
 test "yellow and violet" {
     const array = [_]ColorBand{.yellow, .violet};
     const expected = 47;
-    const actual = comptime try resistor_color_duo.color_code(&array);
+    const actual = comptime try resistor_color_duo.colorCode(&array);
     try testing.expectEqual(expected, actual);
 }
 
 test "orange and orange" {
     const array = [_]ColorBand{.orange, .orange};
     const expected = 33;
-    const actual = comptime try resistor_color_duo.color_code(&array);
+    const actual = comptime try resistor_color_duo.colorCode(&array);
     try testing.expectEqual(expected, actual);
 }
 
 test "ignore additional colors" {
     const array = [_]ColorBand{.green, .brown, .orange};
     const expected = 51;
-    const actual = comptime try resistor_color_duo.color_code(&array);
+    const actual = comptime try resistor_color_duo.colorCode(&array);
     try testing.expectEqual(expected, actual);
 }

--- a/exercises/practice/resistor-color/.meta/example.zig
+++ b/exercises/practice/resistor-color/.meta/example.zig
@@ -16,7 +16,7 @@ const band_colors = [_]ColorBand{
     .green, .blue, .violet, .grey, .white,
 };
 
-pub fn color_code(color: ColorBand) isize {
+pub fn colorCode(color: ColorBand) isize {
     return @enumToInt(color);
 }
 

--- a/exercises/practice/resistor-color/resistor_color.zig
+++ b/exercises/practice/resistor-color/resistor_color.zig
@@ -1,4 +1,4 @@
-pub fn color_code(color: ColorBand) isize {
+pub fn colorCode(color: ColorBand) isize {
     @panic("determine the value of a colorband on a resistor");
 }
 

--- a/exercises/practice/resistor-color/test_resistor_color.zig
+++ b/exercises/practice/resistor-color/test_resistor_color.zig
@@ -6,19 +6,19 @@ const ColorBand = resistor_color.ColorBand;
 
 test "test black" {
     const expected = 0;
-    const actual = comptime resistor_color.color_code(.black);
+    const actual = comptime resistor_color.colorCode(.black);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "test white" {
     const expected = 9;
-    const actual = comptime resistor_color.color_code(.white);
+    const actual = comptime resistor_color.colorCode(.white);
     comptime try testing.expectEqual(expected, actual);
 }
 
 test "test orange" {
     const expected = 3;
-    const actual = comptime resistor_color.color_code(.orange);
+    const actual = comptime resistor_color.colorCode(.orange);
     comptime try testing.expectEqual(expected, actual);
 }
 

--- a/exercises/practice/rna-transcription/test_rna_transcription.zig
+++ b/exercises/practice/rna-transcription/test_rna_transcription.zig
@@ -5,7 +5,7 @@ const testing = std.testing;
 const rna_transcription = @import("rna_transcription.zig");
 const RNAError = rna_transcription.RNAError;
 
-fn test_transcription(
+fn testTranscription(
     dna: []const u8,
     expected: []const u8
 ) !void {
@@ -14,7 +14,7 @@ fn test_transcription(
     testing.allocator.free(rna);
 }
 
-fn test_failure(
+fn testFailure(
     dna: []const u8
 ) !void {
     const expected = RNAError.IllegalDNANucleotide;
@@ -24,25 +24,25 @@ fn test_failure(
 
 
 test "empty rna sequence" {
-    try test_transcription("", "");
+    try testTranscription("", "");
 }
 
 test "rna complement of cytosine is guanine" {
-    try test_transcription("C", "G");
+    try testTranscription("C", "G");
 }
 
 test "rna complement of guanine is cytosine" {
-    try test_transcription("G", "C");
+    try testTranscription("G", "C");
 }
 
 test "rna complement of thymine is adenine" {
-    try test_transcription("T", "A");
+    try testTranscription("T", "A");
 }
 
 test "rna complement of adenine is uracil" {
-    try test_transcription("A", "U");
+    try testTranscription("A", "U");
 }
 
 test "rna complement" {
-    try test_transcription("ACGTGGTCTTAA", "UGCACCAGAAUU");
+    try testTranscription("ACGTGGTCTTAA", "UGCACCAGAAUU");
 }

--- a/exercises/practice/two-fer/.meta/example.zig
+++ b/exercises/practice/two-fer/.meta/example.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const fmt = std.fmt;
 
-pub fn two_fer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
+pub fn twoFer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
     var word = if (name == null) "me" else name;
     var slice = try fmt.bufPrint(buffer, "One for {?s}, one for you.", .{word});
     return slice;

--- a/exercises/practice/two-fer/test_two_fer.zig
+++ b/exercises/practice/two-fer/test_two_fer.zig
@@ -8,20 +8,20 @@ const BUFFER_SIZE = 100;
 test "no name given" {
     var response: [BUFFER_SIZE]u8 = undefined;
     const expected = "One for me, one for you.";
-    const actual = try two_fer.two_fer(&response, null);
+    const actual = try two_fer.twoFer(&response, null);
     try testing.expectEqualStrings(expected, actual);
 }
 
 test "a name given" {
     var response: [BUFFER_SIZE]u8 = undefined;
     const expected = "One for Alice, one for you.";
-    const actual = try two_fer.two_fer(&response, "Alice");
+    const actual = try two_fer.twoFer(&response, "Alice");
     try testing.expectEqualStrings(expected, actual);
 }
 
 test "another name given" {
     var response: [BUFFER_SIZE]u8 = undefined;
     const expected = "One for Bob, one for you.";
-    const actual = try two_fer.two_fer(&response, "Bob");
+    const actual = try two_fer.twoFer(&response, "Bob");
     try testing.expectEqualStrings(expected, actual);
 }

--- a/exercises/practice/two-fer/two_fer.zig
+++ b/exercises/practice/two-fer/two_fer.zig
@@ -1,3 +1,3 @@
-pub fn two_fer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
+pub fn twoFer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
     @panic("respond with the appropriate message given a particular name");
 }


### PR DESCRIPTION
From the [Zig Style Guide][1]:

> Roughly speaking: `camelCaseFunctionName`, `TitleCaseTypeName`, `snake_case_variable_name`. More precisely:
> 
> - If `x` is a `type` then `x` should be `TitleCase`, unless it is a `struct` with 0 fields and is never meant to be instantiated, in which case it is considered to be a "namespace" and uses `snake_case`.
> 
> - If `x` is callable, and `x`'s return type is `type`, then `x` should be `TitleCase`.
> 
> - If `x` is otherwise callable, then `x` should be `camelCase`.
> 
> - Otherwise, `x` should be `snake_case`.

[1]: https://ziglang.org/documentation/0.10.1/#Style-Guide