### PR TITLE
exercises: use snake_case for variable names

### DIFF
--- a/exercises/practice/grains/.meta/example.zig
+++ b/exercises/practice/grains/.meta/example.zig
@@ -3,10 +3,10 @@ const math = std.math;
 
 pub const ChessboardError = error{IndexOutOfBounds};
 
-const NUMBER_OF_CHESS_SQUARES = 64;
+const number_of_chess_squares = 64;
 
 pub fn square(index: isize) ChessboardError!u64 {
-    if (index > NUMBER_OF_CHESS_SQUARES or index <= 0) {
+    if (index > number_of_chess_squares or index <= 0) {
         return ChessboardError.IndexOutOfBounds;
     }
     return @as(u64, 1) << @truncate(u6, @bitCast(usize, index) - 1);

--- a/exercises/practice/space-age/.meta/example.zig
+++ b/exercises/practice/space-age/.meta/example.zig
@@ -12,7 +12,7 @@ pub const Planet = enum(u4) {
 pub const SpaceAge = struct {
     seconds: f64,
 
-    const EARTH_YEAR_IN_SECONDS = 31557600;
+    const earth_year_in_seconds = 31557600;
 
     pub fn init(seconds: isize) SpaceAge {
         return SpaceAge {
@@ -21,7 +21,7 @@ pub const SpaceAge = struct {
     }
 
     fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
-        return EARTH_YEAR_IN_SECONDS *
+        return earth_year_in_seconds *
             getOrbitalPeriodInEarthYearsOf(planet);
     }
 

--- a/exercises/practice/two-fer/test_two_fer.zig
+++ b/exercises/practice/two-fer/test_two_fer.zig
@@ -3,24 +3,24 @@ const testing = std.testing;
 
 const two_fer = @import("two_fer.zig");
 
-const BUFFER_SIZE = 100;
+const buffer_size = 100;
 
 test "no name given" {
-    var response: [BUFFER_SIZE]u8 = undefined;
+    var response: [buffer_size]u8 = undefined;
     const expected = "One for me, one for you.";
     const actual = try two_fer.two_fer(&response, null);
     try testing.expectEqualStrings(expected, actual);
 }
 
 test "a name given" {
-    var response: [BUFFER_SIZE]u8 = undefined;
+    var response: [buffer_size]u8 = undefined;
     const expected = "One for Alice, one for you.";
     const actual = try two_fer.two_fer(&response, "Alice");
     try testing.expectEqualStrings(expected, actual);
 }
 
 test "another name given" {
-    var response: [BUFFER_SIZE]u8 = undefined;
+    var response: [buffer_size]u8 = undefined;
     const expected = "One for Bob, one for you.";
     const actual = try two_fer.two_fer(&response, "Bob");
     try testing.expectEqualStrings(expected, actual);


### PR DESCRIPTION
From the [Zig Style Guide][1]:

> Roughly speaking: `camelCaseFunctionName`, `TitleCaseTypeName`, `snake_case_variable_name`. More precisely:
> 
> - If `x` is a `type` then `x` should be `TitleCase`, unless it is a `struct` with 0 fields and is never meant to be instantiated, in which case it is considered to be a "namespace" and uses `snake_case`.
> 
> - If `x` is callable, and `x`'s return type is `type`, then `x` should be `TitleCase`.
> 
> - If `x` is otherwise callable, then `x` should be `camelCase`.
> 
> - Otherwise, `x` should be `snake_case`.

[1]: https://ziglang.org/documentation/0.10.1/#Style-Guide