### PR TITLE
exercises: use camelCase for acronyms

### DIFF
--- a/exercises/practice/hamming/.meta/example.zig
+++ b/exercises/practice/hamming/.meta/example.zig
@@ -1,17 +1,17 @@
-pub const DNAError = error {
-    EmptyDNAStrands,
-    UnequalDNAStrands,
+pub const DnaError = error {
+    EmptyDnaStrands,
+    UnequalDnaStrands,
 };
 
 pub fn compute(
     first: []const u8,
     second: []const u8
-) DNAError!usize {
+) DnaError!usize {
     if (first.len == 0 or second.len == 0) {
-        return DNAError.EmptyDNAStrands;
+        return DnaError.EmptyDnaStrands;
     }
     if (first.len != second.len) {
-        return DNAError.UnequalDNAStrands;
+        return DnaError.UnequalDnaStrands;
     }
     var hamming_distance: usize = 0;
     for (first) |rune, i| {

--- a/exercises/practice/hamming/hamming.zig
+++ b/exercises/practice/hamming/hamming.zig
@@ -1,6 +1,6 @@
 pub fn compute(
     first: []const u8,
     second: []const u8
-) DNAError!usize {
+) DnaError!usize {
     @panic("please implement the compute function");
 }

--- a/exercises/practice/hamming/test_hamming.zig
+++ b/exercises/practice/hamming/test_hamming.zig
@@ -2,10 +2,10 @@ const std = @import("std");
 const testing = std.testing;
 
 const hamming = @import("hamming.zig");
-const DNAError = hamming.DNAError;
+const DnaError = hamming.DnaError;
 
 test "empty strands" {
-    const expected = DNAError.EmptyDNAStrands;
+    const expected = DnaError.EmptyDnaStrands;
     const actual = comptime hamming.compute("", "");
     try testing.expectError(expected, actual);
 }
@@ -37,25 +37,25 @@ test "long different strands" {
 }
 
 test "disallow first strand longer" {
-    const expected = DNAError.UnequalDNAStrands;
+    const expected = DnaError.UnequalDnaStrands;
     const actual = comptime hamming.compute("AATG", "AAA");
     try testing.expectError(expected, actual);
 }
 
 test "disallow second strand longer" {
-    const expected = DNAError.UnequalDNAStrands;
+    const expected = DnaError.UnequalDnaStrands;
     const actual = comptime hamming.compute("ATA", "AGTG");
     try testing.expectError(expected, actual);
 }
 
 test "disallow left empty strand" {
-    const expected = DNAError.EmptyDNAStrands;
+    const expected = DnaError.EmptyDnaStrands;
     const actual = comptime hamming.compute("", "G");
     try testing.expectError(expected, actual);
 }
 
 test "disallow right empty strand" {
-    const expected = DNAError.EmptyDNAStrands;
+    const expected = DnaError.EmptyDnaStrands;
     const actual = comptime hamming.compute("G", "");
     try testing.expectError(expected, actual);
 }

--- a/exercises/practice/rna-transcription/.meta/example.zig
+++ b/exercises/practice/rna-transcription/.meta/example.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const mem = std.mem;
 
-pub const RNAError = error {
-    IllegalDNANucleotide,
+pub const RnaError = error {
+    IllegalDnaNucleotide,
 };
 
 pub fn toRna(
@@ -18,7 +18,7 @@ pub fn toRna(
             'T' => rna_slice[i] = 'A',
             else => {
                 allocator.free(rna_slice);
-                return RNAError.IllegalDNANucleotide;
+                return RnaError.IllegalDnaNucleotide;
             },
         }
     }

--- a/exercises/practice/rna-transcription/rna_transcription.zig
+++ b/exercises/practice/rna-transcription/rna_transcription.zig
@@ -3,6 +3,6 @@
 pub fn toRna(
     allocator: mem.Allocator,
     dna: []const u8
-) (RNAError || mem.Allocator.Error)![]const u8 {
+) (RnaError || mem.Allocator.Error)![]const u8 {
     @panic("please implement the toRna function");
 }

--- a/exercises/practice/rna-transcription/test_rna_transcription.zig
+++ b/exercises/practice/rna-transcription/test_rna_transcription.zig
@@ -3,7 +3,7 @@ const mem = std.mem;
 const testing = std.testing;
 
 const rna_transcription = @import("rna_transcription.zig");
-const RNAError = rna_transcription.RNAError;
+const RnaError = rna_transcription.RnaError;
 
 fn test_transcription(
     dna: []const u8,
@@ -17,7 +17,7 @@ fn test_transcription(
 fn test_failure(
     dna: []const u8
 ) !void {
-    const expected = RNAError.IllegalDNANucleotide;
+    const expected = RnaError.IllegalDnaNucleotide;
     const actual = rna_transcription.toRna(testing.allocator, dna);
     try testing.expectError(expected, actual);
 }


### PR DESCRIPTION
From the [Zig Style Guide][1]:

> Roughly speaking: `camelCaseFunctionName`, `TitleCaseTypeName`, `snake_case_variable_name`. More precisely:
> 
> - If `x` is a `type` then `x` should be `TitleCase`, unless it is a `struct` with 0 fields and is never meant to be instantiated, in which case it is considered to be a "namespace" and uses `snake_case`.
> 
> - If `x` is callable, and `x`'s return type is `type`, then `x` should be `TitleCase`.
> 
> - If `x` is otherwise callable, then `x` should be `camelCase`.
> 
> - Otherwise, `x` should be `snake_case`.
>
> Acronyms, initialisms, proper nouns, or any other word that has capitalization rules in written English are subject to naming conventions just like any other word. Even acronyms that are only 2 letters long are subject to these conventions.

[1]: https://ziglang.org/documentation/0.10.1/#Style-Guide