### PR TITLE
README: remove Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Exercism Zig Track
 
-[![Build Status](https://travis-ci.org/exercism/zig.svg?branch=master)](https://travis-ci.org/exercism/zig)
-
 Exercism exercises in Zig.


### PR DESCRIPTION
This repo no longer uses Travis CI. Commit 1af7db247621 removed the `.travis.yml` file.