### PR TITLE
exercises(triangle): remove duplicate test

### DIFF
--- a/exercises/practice/triangle/test_triangle.zig
+++ b/exercises/practice/triangle/test_triangle.zig
@@ -88,11 +88,6 @@ test "scalene two sides are equal" {
     comptime try testing.expect(!actual.isScalene());
 }
 
-test "scalene two sides are equal" {
-    const actual = comptime try triangle.Triangle.init(4, 4, 3);
-    comptime try testing.expect(!actual.isScalene());
-}
-
 test "scalene may not violate triangle inequality" {
     const actual = triangle.Triangle.init(7, 3, 2);
     try testing.expectError(triangle.TriangleError.InvalidInequality, actual);


### PR DESCRIPTION
The test immediately above is identical.

I've checked that we should remove the test in this PR, rather than changing the values - the number of implemented tests now matches the number of tests in `.meta/tests.toml`:

https://github.com/exercism/zig/blob/a0b53c56d0b5ac35988eb7b91495bcdbd50dbdfd/exercises/practice/triangle/.meta/tests.toml#L57-L67

I'll add the new upstream tests in a follow-up PR.