### PR TITLE
docs: use one sentence per line

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,12 +1,19 @@
 # About
 
-Zig is a general-purpose programming language equipped with well-rounded toolchains that aims to be simple and familiar, yet disparate from what programmers rely on today. Its main attributes involve helping programmers to develop **robust**, **optimal**, and **reusable** software. All the while, Zig aims to remedy the design problems of older languages with features that promote safety through the use of [optionals][optionals], a unique take on [error handling][error-handling], and [compile-time execution][compile-time].
+Zig is a general-purpose programming language equipped with well-rounded toolchains that aims to be simple and familiar, yet disparate from what programmers rely on today.
+Its main attributes involve helping programmers to develop **robust**, **optimal**, and **reusable** software.
+All the while, Zig aims to remedy the design problems of older languages with features that promote safety through the use of [optionals][optionals], a unique take on [error handling][error-handling], and [compile-time execution][compile-time].
 
-From the ground up, Zig was designed to be competitive with other systems programming languages and not be reliant on them. With bold claims such as, "Zig is faster than C" featured on it's home page, being independent from other languages is a major design philosophy that it champions.
+From the ground up, Zig was designed to be competitive with other systems programming languages and not be reliant on them.
+With bold claims such as, "Zig is faster than C" featured on it's home page, being independent from other languages is a major design philosophy that it champions.
 
-Zig has a lot of faculties that really makes it double down on it's notion of independence. The standard library that Zig provides harbors many common functions that perform fast to ensure that a reliance on FFI and external libraries is not essential. Zig also provides a well-rounded [build system][build-system] so that Zig is not dependent on alternative build tools, such as make, cmake, or ninja.
+Zig has a lot of faculties that really makes it double down on it's notion of independence.
+The standard library that Zig provides harbors many common functions that perform fast to ensure that a reliance on FFI and external libraries is not essential.
+Zig also provides a well-rounded [build system][build-system] so that Zig is not dependent on alternative build tools, such as make, cmake, or ninja.
 
-The home page for Zig is [ziglang.org][ziglang.org]. Zig provides a complete summary of the language's current features, grammars, and philosophies at [ziglang.org/documentation/master/][ziglang.org/docs]. It's highly recommended that newcomers use a mix of the documentation and other [community resources][zig-community] to learn Zig in a well-rounded fashion.
+The home page for Zig is [ziglang.org][ziglang.org].
+Zig provides a complete summary of the language's current features, grammars, and philosophies at [ziglang.org/documentation/master/][ziglang.org/docs].
+It's highly recommended that newcomers use a mix of the documentation and other [community resources][zig-community] to learn Zig in a well-rounded fashion.
 
 [build-system]: https://ziglang.org/#Zig-Build-System
 [compile-time]: https://ziglang.org/#Compile-time-reflection-and-compile-time-code-execution

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,14 +1,18 @@
 # Installation
 
-There are many ways to install Zig, and the number of ways to install Zig are steadily increasing as the language matures. Fortunately, all of the popular installation methods are listed on the [Zig install page][install-zig].
+There are many ways to install Zig, and the number of ways to install Zig are steadily increasing as the language matures.
+Fortunately, all of the popular installation methods are listed on the [Zig install page][install-zig].
 
 ## Additional utilities
 
 ### Zig fmt - Generating well-formatted code
 
-When completing any exercise, you may use all kinds of code styles for your solutions. However, outside of solving exercises, such as making applications or libraries, it's typically a good idea to make your code consistent and readable. Those assumption are especially important when others who would want to help out with your projects would have to read your code.
+When completing any exercise, you may use all kinds of code styles for your solutions.
+However, outside of solving exercises, such as making applications or libraries, it's typically a good idea to make your code consistent and readable.
+Those assumption are especially important when others who would want to help out with your projects would have to read your code.
 
-To fix this problem the Zig compiler comes with a built-in lightweight [linter][linters] to format your code in a convenient manner. This code formatter aims to follow the [style guide][style-guide] already established by the [Zig documentation][documentation].
+To fix this problem the Zig compiler comes with a built-in lightweight [linter][linters] to format your code in a convenient manner.
+This code formatter aims to follow the [style guide][style-guide] already established by the [Zig documentation][documentation].
 
 To see the features of Zig's native formatter use the following command:
 
@@ -18,7 +22,8 @@ zig fmt --help
 
 ### Zig Zen - Rules to code by!
 
-Sometimes some direction goes a long way when completing any task, even when writing code. Thankfully we have a fun command built right into the Zig compiler to remind ourselves of some of the goals that go into writing good Zig code.
+Sometimes some direction goes a long way when completing any task, even when writing code.
+Thankfully we have a fun command built right into the Zig compiler to remind ourselves of some of the goals that go into writing good Zig code.
 
 To check out these words of wisdom you can use the following command:
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,7 +1,8 @@
 # Learning
 
 * [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
-* [Awesome Zig][awesome-zig] is a good collection of Zig projects made by various people. The collection features projects involving well developed Zig code.
+* [Awesome Zig][awesome-zig] is a good collection of Zig projects made by various people.
+  The collection features projects involving well developed Zig code.
 * [Zig Launch][zig-launch] is a assortment of Zig examples that demonstrates very specific Zig features.
 * [ZigLearn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
 * [Zig SHOWTIME][zig-showtime] is a livestreamed show where members of the Zig community share code and ideas.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -5,7 +5,8 @@
 * [#zig][irc] on irc.freenode.net is the main Zig IRC channel.
 * [Stack Overflow][stack-overflow] can be used to discover code snippets and solutions to problems that may have already asked and maybe solved by others.
 * [/r/Zig][reddit] is the main Zig subreddit.
-* [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord]. It provides a great way to get in touch with the Zig community at large, and get some quick, direct help for any Zig related problem.
+* [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord].
+  It provides a great way to get in touch with the Zig community at large, and get some quick, direct help for any Zig related problem.
 * [The Zig SHOWTIME Newsletter][newsletter] announces new episodes, important events, and links to interesting new Zig projects.
 
 [awesome-zig]: https://github.com/nrdmn/awesome-zig

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,8 +1,11 @@
 # Writing the Code
 
-Write your code in `<exercise-name>.zig`. Some exercises come with prewritten signatures for specific Zig constructs, such as [constants][constants], [functions][functions], [imports][imports], [structs][structs], and [potentially many more][et-cetera]!
+Write your code in `<exercise-name>.zig`.
+Some exercises come with prewritten signatures for specific Zig constructs, such as [constants][constants], [functions][functions], [imports][imports], [structs][structs], and [potentially many more][et-cetera]!
 
-These prewritten signatures are meant to help you towards completing exercises by providing a clear starting point. However, starting from these signatures is not necessary. Especially when any written code which passes their tests are perfectly acceptable solutions.
+These prewritten signatures are meant to help you towards completing exercises by providing a clear starting point.
+However, starting from these signatures is not necessary.
+Especially when any written code which passes their tests are perfectly acceptable solutions.
 
 ## Running Tests
 
@@ -12,9 +15,12 @@ To run the tests, all you need to do is run the following command:
 $ zig test test.zig
 ```
 
-The command above has to be run in the exercise's root directory since its test file should be in the same spot. Additionally, all of the tests for any given exercise are enabled by default, and none of the tests are skippable.
+The command above has to be run in the exercise's root directory since its test file should be in the same spot.
+Additionally, all of the tests for any given exercise are enabled by default, and none of the tests are skippable.
 
-Since all tests have these stipulations, you would have to [comment out][comments] tests that are not passing if you wish to go through each test one by one. Commenting out a test is as simple as starting each line with a `//`. Otherwise, when you're confident that your solution can pass the tests, you can un-comment those tests to see if it passes.
+Since all tests have these stipulations, you would have to [comment out][comments] tests that are not passing if you wish to go through each test one by one.
+Commenting out a test is as simple as starting each line with a `//`.
+Otherwise, when you're confident that your solution can pass the tests, you can un-comment those tests to see if it passes.
 
 [constants]: https://ziglang.org/documentation/master/#Assignment
 [comments]: https://ziglang.org/documentation/master/#Comments

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -2,7 +2,8 @@
 
 - [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
 - [Zig Learn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
-- [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord]. It provides a great way to get in touch with the Zig community at large, and get some quick, direct help for any Zig related problem.
+- [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord].
+  It provides a great way to get in touch with the Zig community at large, and get some quick, direct help for any Zig related problem.
 - [#zig][irc] on irc.freenode.net is the main Zig IRC channel.
 - [/r/Zig][reddit] is the main Zig subreddit.
 - [Stack Overflow][stack-overflow] can be used to discover code snippets and solutions to problems that may have already asked and maybe solved by others.


### PR DESCRIPTION
Comply with the [Exercism Markdown Specification][1]:

>Paragraphs should be laid at using one sentence per line.
>The [Ascii Doctor docs][2] explain the logic of this clearly.
>
>For example, a single paragraph should be laid out as follows:
>
>```
>Exercism has been designed, engineered and built by thousands of very talented individuals.
>Nearly everything with Exercism has been debated, discussed and rewritten many times.
>Exercism is a very intentional product - things are there because they've been designed to be there, and things are often left out because they've been designed to be left out.
>```

[1]: https://github.com/exercism/docs/blob/6a0731ff768f/building/markdown/markdown.md#one-sentence-per-line
[2]: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line