### PR TITLE
exercises(space-age): stub: fix error

### DIFF
--- a/exercises/practice/space-age/space_age.zig
+++ b/exercises/practice/space-age/space_age.zig
@@ -9,13 +9,11 @@ pub const SpaceAge = struct {
     }
 
     fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
-        @panic("please implement the
-            getOrbitalPeriodInSecondsFromEarthYearsOf method");
+        @panic("please implement the getOrbitalPeriodInSecondsFromEarthYearsOf method");
     }
 
     fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
-        @panic("please implement the
-            getOrbitalPeriodInEarthYearsOf method");
+        @panic("please implement the getOrbitalPeriodInEarthYearsOf method");
     }
 
     pub fn onMercury(self: SpaceAge) f64 {


### PR DESCRIPTION
Before this commit, when testing the stub solution:

```console
$ zig test test_space_age.zig
space_age.zig:12:16: error: expected expression, found 'invalid bytes'
        @panic("please implement the
               ^~~~~~~~~~~~~~~~~~~~~
space_age.zig:12:37: note: invalid byte: '\n'
        @panic("please implement the
```

With this commit:

```console
$ zig test test_space_age.zig
space_age.zig:7:17: error: unused function parameter
    pub fn init(seconds: isize) SpaceAge {
                ^~~~~~~
space_age.zig:11:58: error: use of undeclared identifier 'Planet'
    fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
                                                         ^~~~~~
space_age.zig:15:47: error: use of undeclared identifier 'Planet'
    fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
                                              ^~~~~~
space_age.zig:19:22: error: unused function parameter
    pub fn onMercury(self: SpaceAge) f64 {
                     ^~~~
space_age.zig:23:20: error: unused function parameter
    pub fn onVenus(self: SpaceAge) f64 {
                   ^~~~
space_age.zig:27:20: error: unused function parameter
    pub fn onEarth(self: SpaceAge) f64 {
                   ^~~~
space_age.zig:31:19: error: unused function parameter
    pub fn onMars(self: SpaceAge) f64 {
                  ^~~~
space_age.zig:35:22: error: unused function parameter
    pub fn onJupiter(self: SpaceAge) f64 {
                     ^~~~
space_age.zig:39:21: error: unused function parameter
    pub fn onSaturn(self: SpaceAge) f64 {
                    ^~~~
space_age.zig:43:21: error: unused function parameter
    pub fn onUranus(self: SpaceAge) f64 {
                    ^~~~
space_age.zig:47:22: error: unused function parameter
    pub fn onNeptune(self: SpaceAge) f64 {
                     ^~~~
```