### PR TITLE
exercises: remove ErikSchierboom and iHiD from contributors

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "collatz_conjecture.zig"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "darts.zig"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "difference_of_squares.zig"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "grains.zig"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "hamming.zig"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "hello_world.zig"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "leap.zig"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "pangram.zig"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "resistor_color_duo.zig"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "resistor_color.zig"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "rna_transcription.zig"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "space_age.zig"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "triangle.zig"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -2,10 +2,6 @@
   "authors": [
     "massivelivefun"
   ],
-  "contributors": [
-    "ErikSchierboom",
-    "iHiD"
-  ],
   "files": {
     "solution": [
       "two_fer.zig"


### PR DESCRIPTION
These were present due to Exercism-wide PRs, which aren't supposed to count towards `contributors` (see commit message for 973e7548eb11, and [docs](https://github.com/exercism/docs/blob/6a0731ff768f/building/tracks/practice-exercises.md#file-metaconfigjson)).

---

GitHub links:

- https://github.com/exercism/zig/commits?author=ErikSchierboom
- https://github.com/exercism/zig/commits?author=ihid

@ErikSchierboom please let me know if https://github.com/exercism/zig/commit/00505196ce96a1963b83b67f732b6c12bf7d70f4 should count.