### PR TITLE
docs(LEARNING): update awesome-zig link

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -7,7 +7,7 @@
 * [ZigLearn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
 * [Zig SHOWTIME][zig-showtime] is a livestreamed show where members of the Zig community share code and ideas.
 
-[awesome-zig]: https://github.com/nrdmn/awesome-zig
+[awesome-zig]: https://github.com/catdevnull/awesome-zig
 [documentation]: https://ziglang.org/documentation/master/
 [zig-launch]: https://ziglaunch.org/
 [zig-learn]: https://ziglearn.org/


### PR DESCRIPTION
The previously linked repo was last updated on 2020-11-14. There are at least two awesome-zig repos (by C-BJ and catdevnull) that we could link to instead. For now let's use catdevnull's, which is the one [currently mentioned in the Zig Wiki][1] and in [the most starred "awesome list" on GitHub][2].

[1]: https://github.com/ziglang/zig/wiki/Community-Projects
[2]: https://github.com/sindresorhus/awesome/tree/c9da614a2b71#programming-languages

---

Alternative to https://github.com/exercism/zig/pull/158.