### PR TITLE
exercises(grains): talk about errors, not exceptions

### DIFF
--- a/exercises/practice/grains/test_grains.zig
+++ b/exercises/practice/grains/test_grains.zig
@@ -46,19 +46,19 @@ test "grains on square 64" {
     try testing.expectEqual(expected, actual);
 }
 
-test "square 0 raises an exception" {
+test "square 0 produces an error" {
     const expected = ChessboardError.IndexOutOfBounds;
     const actual = comptime grains.square(0);
     try testing.expectError(expected, actual);
 }
 
-test "negative square raises an expection" {
+test "negative square produces an error" {
     const expected = ChessboardError.IndexOutOfBounds;
     const actual = comptime grains.square(-1);
     try testing.expectError(expected, actual);
 }
 
-test "square greater than 64 raises an exception" {
+test "square greater than 64 produces an error" {
     const expected = ChessboardError.IndexOutOfBounds;
     const actual = comptime grains.square(65);
     try testing.expectError(expected, actual);


### PR DESCRIPTION
Zig does not have exceptions.

Closes: #144

---

With this PR, we have no more user-facing mentions of "exception":

```console
$ git rev-parse --short HEAD
337cd46
$ git grep --break --heading 'exception'
exercises/practice/grains/.meta/tests.toml
34:description = "returns the number of grains on the square -> square 0 raises an exception"
37:description = "returns the number of grains on the square -> negative square raises an exception"
40:description = "returns the number of grains on the square -> square greater than 64 raises an exception"
```