### PR TITLE
config: add `files` data

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,20 @@
   "test_runner": {
     "average_run_time": 5.0
   },
+  "files": {
+    "solution": [
+      "%{snake_slug}.zig"
+    ],
+    "test": [
+      "test_%{snake_slug}.zig"
+    ],
+    "example": [
+      ".meta/example.zig"
+    ],
+    "exemplar": [
+      ".meta/exemplar.zig"
+    ]
+  },
   "exercises": {
     "concept": [],
     "practice": [


### PR DESCRIPTION
Allow configlet to populate the `files` key in an exercise `.meta/config.json` file.

---

The naming convention used in the Zig track:

https://github.com/exercism/zig/blob/0c82fecf42f129ae26f02634755fd921c213c05c/exercises/practice/two-fer/.meta/config.json#L5-L15