### PR TITLE
config: tags: change `typing/weak` to `typing/strong`

### DIFF
--- a/config.json
+++ b/config.json
@@ -475,7 +475,7 @@
     "paradigm/imperative",
     "paradigm/procedural",
     "typing/static",
-    "typing/weak",
+    "typing/strong",
     "execution_mode/compiled",
     "platform/windows",
     "platform/mac",


### PR DESCRIPTION
If we have a choice between saying Zig is "strongly typed" or "weakly typed", then I think it's better to say the first. 

There is no well-defined meaning of these terms. It's true that Zig has `anytype` and compile-time duck typing, but the type system is arguably stricter than a lot of statically typed languages, casting is explicit, and type coercion only happens when its safe/unambiguous.

In practice, I think when most people think of "weakly typed" they either confuse it for "dynamically typed", or think about implicit conversions like:

```
11 + "22"
"1122"
``` 

And Zig is a world away from that.

The only other languages that appear as "weakly typed" on Exercism right now are:

- coffeescript
- javascript
- mips
- perl
- raku
- typescript
- vbnet
- vimscript
- wasm
- x86-64-assembly