### PR TITLE
.github: add markdownlint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,14 @@
+name: markdownlint
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  markdownlint:
+    name: Lint markdown files
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@5b7c9f74fec47e6b15667b2cc23c63dff11e449e

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,22 @@
+# For information on configuring markdownlint, see:
+# https://github.com/DavidAnson/markdownlint
+config:
+  MD003:
+    style: 'atx'    # Forbid setext-style headers and closed-ATX-style headers
+  MD004:
+    style: 'dash'   # Require `-` for every unordered list item
+  MD013: false      # Permit long lines
+  MD029:
+    style: 'one'    # Require each ordered list item to begin with `1.`
+  MD035:
+    style: '---'    # Require `---` for every horizontal rule
+  MD046:
+    style: 'fenced' # Forbid using indentation for code blocks
+
+globs:
+  - "**/*.md"
+
+# Ignore files that are synced
+ignores:
+  - "exercises/practice/*/.docs/instructions.md"
+  - "exercises/practice/*/.docs/introduction.md"


### PR DESCRIPTION
Make CI fail if repo-specific Markdown files violate some [`markdownlint` rules][1].

See also the [Exercism Markdown Specification][2].

[1]: https://github.com/DavidAnson/markdownlint/blob/v0.26.2/doc/Rules.md
[2]: https://github.com/exercism/docs/blob/792656920b46/building/markdown/markdown.md

---

Workflow and config taken from `exercism/nim`: https://github.com/exercism/nim/commit/d9923100b3537c93b82955c7278c3a75ebfa2a6e