### PR TITLE
exercises: stubs: resolve unused parameter errors

### DIFF
--- a/exercises/practice/binary-search/binary_search.zig
+++ b/exercises/practice/binary-search/binary_search.zig
@@ -1,5 +1,7 @@
 // Take a look at the tests, you might have to change the function arguments
 
 pub fn binarySearch(target: usize, buffer: ?[]const usize) SearchError!usize {
+    _ = target;
+    _ = buffer;
     @panic("please implement the binarySearch function");
 }

--- a/exercises/practice/collatz-conjecture/collatz_conjecture.zig
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture.zig
@@ -1,3 +1,4 @@
 pub fn steps(number: isize) anyerror!usize {
+    _ = number;
     @panic("please implement the steps function");
 }

--- a/exercises/practice/darts/darts.zig
+++ b/exercises/practice/darts/darts.zig
@@ -2,9 +2,12 @@ pub const Coordinate = struct {
     // This struct, as well as its fields and methods, needs to be implemented.
 
     pub fn init(x_coord: f32, y_coord: f32) Coordinate {
+        _ = x_coord;
+        _ = y_coord;
         @panic("please implement the init method");
     }
     pub fn score(self: Coordinate) isize {
+        _ = self;
         @panic("please implement the score method");
     }
 };

--- a/exercises/practice/difference-of-squares/difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/difference_of_squares.zig
@@ -1,11 +1,14 @@
 pub fn squareOfSum(number: isize) isize {
+    _ = number;
     @panic("compute the sum of i from 0 to n then square it");
 }
 
 pub fn sumOfSquares(number: isize) isize {
+    _ = number;
     @panic("compute the sum of i^2 from 0 to n");
 }
 
 pub fn differenceOfSquares(number: isize) isize {
+    _ = number;
     @panic("compute the difference between the square of sum and sum of squares");
 }

--- a/exercises/practice/grains/grains.zig
+++ b/exercises/practice/grains/grains.zig
@@ -1,4 +1,5 @@
 pub fn square(index: isize) ChessboardError!u64 {
+    _ = index;
     @panic("please implement the square function");
 }
 

--- a/exercises/practice/hamming/hamming.zig
+++ b/exercises/practice/hamming/hamming.zig
@@ -1,3 +1,5 @@
 pub fn compute(first: []const u8, second: []const u8) DnaError!usize {
+    _ = first;
+    _ = second;
     @panic("please implement the compute function");
 }

--- a/exercises/practice/isogram/isogram.zig
+++ b/exercises/practice/isogram/isogram.zig
@@ -1,3 +1,4 @@
 pub fn isIsogram(str: []const u8) bool {
+    _ = str;
     @panic("please implement the isIsogram function");
 }

--- a/exercises/practice/leap/leap.zig
+++ b/exercises/practice/leap/leap.zig
@@ -1,3 +1,4 @@
 pub fn isLeapYear(year: u32) bool {
+    _ = year;
     @panic("please implement the isLeapYear function");
 }

--- a/exercises/practice/pangram/pangram.zig
+++ b/exercises/practice/pangram/pangram.zig
@@ -1,3 +1,4 @@
 pub fn isPangram(str: []const u8) bool {
+    _ = str;
     @panic("please implement the isPangram function");
 }

--- a/exercises/practice/proverb/proverb.zig
+++ b/exercises/practice/proverb/proverb.zig
@@ -1,3 +1,5 @@
 pub fn recite(allocator: mem.Allocator, words: []const []const u8) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
+    _ = allocator;
+    _ = words;
     @panic("please implement the recite function");
 }

--- a/exercises/practice/rna-transcription/rna_transcription.zig
+++ b/exercises/practice/rna-transcription/rna_transcription.zig
@@ -1,5 +1,7 @@
 // Import the appropriate standard library and modules
 
 pub fn toRna(allocator: mem.Allocator, dna: []const u8) (RnaError || mem.Allocator.Error)![]const u8 {
+    _ = allocator;
+    _ = dna;
     @panic("please implement the toRna function");
 }

--- a/exercises/practice/secret-handshake/secret_handshake.zig
+++ b/exercises/practice/secret-handshake/secret_handshake.zig
@@ -1,3 +1,5 @@
 pub fn calculateHandshake(allocator: mem.Allocator, number: isize) mem.Allocator.Error![]const Signal {
+    _ = allocator;
+    _ = number;
     @panic("please implement the calculateHandshake function");
 }

--- a/exercises/practice/space-age/space_age.zig
+++ b/exercises/practice/space-age/space_age.zig
@@ -5,46 +5,57 @@ pub const SpaceAge = struct {
     // implemented.
 
     pub fn init(seconds: isize) SpaceAge {
+        _ = seconds;
         @panic("please implement the init method");
     }
 
     fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
+        _ = planet;
         @panic("please implement the getOrbitalPeriodInSecondsFromEarthYearsOf method");
     }
 
     fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
+        _ = planet;
         @panic("please implement the getOrbitalPeriodInEarthYearsOf method");
     }
 
     pub fn onMercury(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onMercury method");
     }
 
     pub fn onVenus(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onVenus method");
     }
 
     pub fn onEarth(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onEarth method");
     }
 
     pub fn onMars(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onMars method");
     }
 
     pub fn onJupiter(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onJupiter method");
     }
 
     pub fn onSaturn(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onSaturn method");
     }
 
     pub fn onUranus(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onUranus method");
     }
 
     pub fn onNeptune(self: SpaceAge) f64 {
+        _ = self;
         @panic("please implement the onNeptune method");
     }
 };

--- a/exercises/practice/triangle/triangle.zig
+++ b/exercises/practice/triangle/triangle.zig
@@ -2,26 +2,38 @@ pub const Triangle = struct {
     // This struct, as well as its fields and methods, needs to be implemented.
 
     pub fn init(first: f64, second: f64, third: f64) TriangleError!Triangle {
+        _ = first;
+        _ = second;
+        _ = third;
         @panic("please implement the init method");
     }
 
     fn verifyIfDegenerateAttributesExist(first: f64, second: f64, third: f64) TriangleError!void {
+        _ = first;
+        _ = second;
+        _ = third;
         @panic("optional verifyIfDegenerateAttributesExist method");
     }
 
     fn verifyIfTriangleInequalityHolds(first: f64, second: f64, third: f64) TriangleError!void {
+        _ = first;
+        _ = second;
+        _ = third;
         @panic("please implement the verifyIfTriangleInequalityHolds method");
     }
 
     pub fn isEquilateral(self: Triangle) bool {
+        _ = self;
         @panic("please implement the isEquilateral method");
     }
 
     pub fn isIsosceles(self: Triangle) bool {
+        _ = self;
         @panic("please implement the isIsosceles method");
     }
 
     pub fn isScalene(self: Triangle) bool {
+        _ = self;
         @panic("please implement the isScalene method");
     }
 };

--- a/exercises/practice/two-fer/two_fer.zig
+++ b/exercises/practice/two-fer/two_fer.zig
@@ -1,3 +1,5 @@
 pub fn twoFer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
+    _ = buffer;
+    _ = name;
     @panic("respond with the appropriate message given a particular name");
 }


### PR DESCRIPTION
Before this commit, when testing an unchanged exercise stub:

```console
$ zig test test_leap.zig
leap.zig:1:19: error: unused function parameter
pub fn isLeapYear(year: u32) bool {
                  ^~~~
```

With this commit:

```console
$ zig test test_leap.zig
Test [1/9] test.year not divisible by 4 in common year... thread 123456 panic: please implement the isLeapYear function
/foo/exercism-tracks/zig/exercises/practice/leap/leap.zig:3:5: 0x201234 in isLeapYear (test)
    @panic("please implement the isLeapYear function");
[...]
```

Closes: #175

---

Refs: #143

With this PR, there are no more unused parameter errors when running `zig fmt . --ast-check`. This gets us closer to checking stubs in CI.

```console
$ zig fmt . --ast-check
./exercises/practice/binary-search/binary_search.zig:3:60: error: use of undeclared identifier 'SearchError'
pub fn binarySearch(target: usize, buffer: ?[]const usize) SearchError!usize {
                                                           ^~~~~~~~~~~
./exercises/practice/grains/grains.zig:1:29: error: use of undeclared identifier 'ChessboardError'
pub fn square(index: isize) ChessboardError!u64 {
                            ^~~~~~~~~~~~~~~
./exercises/practice/hamming/hamming.zig:1:55: error: use of undeclared identifier 'DnaError'
pub fn compute(first: []const u8, second: []const u8) DnaError!usize {
                                                      ^~~~~~~~
./exercises/practice/proverb/proverb.zig:1:26: error: use of undeclared identifier 'mem'
pub fn recite(allocator: mem.Allocator, words: []const []const u8) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
                         ^~~
./exercises/practice/resistor-color-duo/resistor_color_duo.zig:1:34: error: use of undeclared identifier 'ColorBand'
pub fn colorCode(colors: []const ColorBand) anyerror!isize {
                                 ^~~~~~~~~
./exercises/practice/resistor-color/resistor_color.zig:1:25: error: use of undeclared identifier 'ColorBand'
pub fn colorCode(color: ColorBand) isize {
                        ^~~~~~~~~
./exercises/practice/resistor-color/resistor_color.zig:5:25: error: use of undeclared identifier 'ColorBand'
pub fn colors() []const ColorBand {
                        ^~~~~~~~~
./exercises/practice/rna-transcription/rna_transcription.zig:3:25: error: use of undeclared identifier 'mem'
pub fn toRna(allocator: mem.Allocator, dna: []const u8) (RnaError || mem.Allocator.Error)![]const u8 {
                        ^~~
./exercises/practice/secret-handshake/secret_handshake.zig:1:38: error: use of undeclared identifier 'mem'
pub fn calculateHandshake(allocator: mem.Allocator, number: isize) mem.Allocator.Error![]const Signal {
                                     ^~~
./exercises/practice/space-age/space_age.zig:12:58: error: use of undeclared identifier 'Planet'
    fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
                                                         ^~~~~~
./exercises/practice/space-age/space_age.zig:17:47: error: use of undeclared identifier 'Planet'
    fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
                                              ^~~~~~
./exercises/practice/triangle/triangle.zig:4:54: error: use of undeclared identifier 'TriangleError'
    pub fn init(first: f64, second: f64, third: f64) TriangleError!Triangle {
                                                     ^~~~~~~~~~~~~
./exercises/practice/triangle/triangle.zig:11:79: error: use of undeclared identifier 'TriangleError'
    fn verifyIfDegenerateAttributesExist(first: f64, second: f64, third: f64) TriangleError!void {
                                                                              ^~~~~~~~~~~~~
./exercises/practice/triangle/triangle.zig:18:77: error: use of undeclared identifier 'TriangleError'
    fn verifyIfTriangleInequalityHolds(first: f64, second: f64, third: f64) TriangleError!void {
                                                                            ^~~~~~~~~~~~~
```