### PR TITLE
exercises: stubs: prefer `@compileError` over `@panic`

### DIFF
--- a/exercises/practice/binary-search/binary_search.zig
+++ b/exercises/practice/binary-search/binary_search.zig
@@ -3,5 +3,5 @@
 pub fn binarySearch(target: usize, buffer: ?[]const usize) SearchError!usize {
     _ = target;
     _ = buffer;
-    @panic("please implement the binarySearch function");
+    @compileError("please implement the binarySearch function");
 }

--- a/exercises/practice/collatz-conjecture/collatz_conjecture.zig
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture.zig
@@ -1,4 +1,4 @@
 pub fn steps(number: isize) anyerror!usize {
     _ = number;
-    @panic("please implement the steps function");
+    @compileError("please implement the steps function");
 }

--- a/exercises/practice/darts/darts.zig
+++ b/exercises/practice/darts/darts.zig
@@ -4,10 +4,10 @@ pub const Coordinate = struct {
     pub fn init(x_coord: f32, y_coord: f32) Coordinate {
         _ = x_coord;
         _ = y_coord;
-        @panic("please implement the init method");
+        @compileError("please implement the init method");
     }
     pub fn score(self: Coordinate) isize {
         _ = self;
-        @panic("please implement the score method");
+        @compileError("please implement the score method");
     }
 };

--- a/exercises/practice/difference-of-squares/difference_of_squares.zig
+++ b/exercises/practice/difference-of-squares/difference_of_squares.zig
@@ -1,14 +1,14 @@
 pub fn squareOfSum(number: isize) isize {
     _ = number;
-    @panic("compute the sum of i from 0 to n then square it");
+    @compileError("compute the sum of i from 0 to n then square it");
 }
 
 pub fn sumOfSquares(number: isize) isize {
     _ = number;
-    @panic("compute the sum of i^2 from 0 to n");
+    @compileError("compute the sum of i^2 from 0 to n");
 }
 
 pub fn differenceOfSquares(number: isize) isize {
     _ = number;
-    @panic("compute the difference between the square of sum and sum of squares");
+    @compileError("compute the difference between the square of sum and sum of squares");
 }

--- a/exercises/practice/grains/grains.zig
+++ b/exercises/practice/grains/grains.zig
@@ -1,8 +1,8 @@
 pub fn square(index: isize) ChessboardError!u64 {
     _ = index;
-    @panic("please implement the square function");
+    @compileError("please implement the square function");
 }
 
 pub fn total() u64 {
-    @panic("please implement the total function");
+    @compileError("please implement the total function");
 }

--- a/exercises/practice/hamming/hamming.zig
+++ b/exercises/practice/hamming/hamming.zig
@@ -1,5 +1,5 @@
 pub fn compute(first: []const u8, second: []const u8) DnaError!usize {
     _ = first;
     _ = second;
-    @panic("please implement the compute function");
+    @compileError("please implement the compute function");
 }

--- a/exercises/practice/isogram/isogram.zig
+++ b/exercises/practice/isogram/isogram.zig
@@ -1,4 +1,4 @@
 pub fn isIsogram(str: []const u8) bool {
     _ = str;
-    @panic("please implement the isIsogram function");
+    @compileError("please implement the isIsogram function");
 }

--- a/exercises/practice/leap/leap.zig
+++ b/exercises/practice/leap/leap.zig
@@ -1,4 +1,4 @@
 pub fn isLeapYear(year: u32) bool {
     _ = year;
-    @panic("please implement the isLeapYear function");
+    @compileError("please implement the isLeapYear function");
 }

--- a/exercises/practice/pangram/pangram.zig
+++ b/exercises/practice/pangram/pangram.zig
@@ -1,4 +1,4 @@
 pub fn isPangram(str: []const u8) bool {
     _ = str;
-    @panic("please implement the isPangram function");
+    @compileError("please implement the isPangram function");
 }

--- a/exercises/practice/proverb/proverb.zig
+++ b/exercises/practice/proverb/proverb.zig
@@ -1,5 +1,5 @@
 pub fn recite(allocator: mem.Allocator, words: []const []const u8) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
     _ = allocator;
     _ = words;
-    @panic("please implement the recite function");
+    @compileError("please implement the recite function");
 }

--- a/exercises/practice/resistor-color-duo/resistor_color_duo.zig
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo.zig
@@ -1,4 +1,4 @@
 pub fn colorCode(colors: [2]ColorBand) isize {
     _ = colors;
-    @compileError("please input the colorCode function");
+    @compileError("please implement the colorCode function");
 }

--- a/exercises/practice/resistor-color/resistor_color.zig
+++ b/exercises/practice/resistor-color/resistor_color.zig
@@ -1,7 +1,7 @@
 pub fn colorCode(color: ColorBand) isize {
-    @panic("determine the value of a colorband on a resistor");
+    @compileError("determine the value of a colorband on a resistor");
 }
 
 pub fn colors() []const ColorBand {
-    @panic("refer to a collection of all resistor colorbands");
+    @compileError("refer to a collection of all resistor colorbands");
 }

--- a/exercises/practice/rna-transcription/rna_transcription.zig
+++ b/exercises/practice/rna-transcription/rna_transcription.zig
@@ -3,5 +3,5 @@
 pub fn toRna(allocator: mem.Allocator, dna: []const u8) (RnaError || mem.Allocator.Error)![]const u8 {
     _ = allocator;
     _ = dna;
-    @panic("please implement the toRna function");
+    @compileError("please implement the toRna function");
 }

--- a/exercises/practice/secret-handshake/secret_handshake.zig
+++ b/exercises/practice/secret-handshake/secret_handshake.zig
@@ -1,5 +1,5 @@
 pub fn calculateHandshake(allocator: mem.Allocator, number: isize) mem.Allocator.Error![]const Signal {
     _ = allocator;
     _ = number;
-    @panic("please implement the calculateHandshake function");
+    @compileError("please implement the calculateHandshake function");
 }

--- a/exercises/practice/space-age/space_age.zig
+++ b/exercises/practice/space-age/space_age.zig
@@ -6,56 +6,56 @@ pub const SpaceAge = struct {
 
     pub fn init(seconds: isize) SpaceAge {
         _ = seconds;
-        @panic("please implement the init method");
+        @compileError("please implement the init method");
     }
 
     fn getOrbitalPeriodInSecondsFromEarthYearsOf(planet: Planet) f64 {
         _ = planet;
-        @panic("please implement the getOrbitalPeriodInSecondsFromEarthYearsOf method");
+        @compileError("please implement the getOrbitalPeriodInSecondsFromEarthYearsOf method");
     }
 
     fn getOrbitalPeriodInEarthYearsOf(planet: Planet) f64 {
         _ = planet;
-        @panic("please implement the getOrbitalPeriodInEarthYearsOf method");
+        @compileError("please implement the getOrbitalPeriodInEarthYearsOf method");
     }
 
     pub fn onMercury(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onMercury method");
+        @compileError("please implement the onMercury method");
     }
 
     pub fn onVenus(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onVenus method");
+        @compileError("please implement the onVenus method");
     }
 
     pub fn onEarth(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onEarth method");
+        @compileError("please implement the onEarth method");
     }
 
     pub fn onMars(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onMars method");
+        @compileError("please implement the onMars method");
     }
 
     pub fn onJupiter(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onJupiter method");
+        @compileError("please implement the onJupiter method");
     }
 
     pub fn onSaturn(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onSaturn method");
+        @compileError("please implement the onSaturn method");
     }
 
     pub fn onUranus(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onUranus method");
+        @compileError("please implement the onUranus method");
     }
 
     pub fn onNeptune(self: SpaceAge) f64 {
         _ = self;
-        @panic("please implement the onNeptune method");
+        @compileError("please implement the onNeptune method");
     }
 };

--- a/exercises/practice/triangle/triangle.zig
+++ b/exercises/practice/triangle/triangle.zig
@@ -5,35 +5,35 @@ pub const Triangle = struct {
         _ = first;
         _ = second;
         _ = third;
-        @panic("please implement the init method");
+        @compileError("please implement the init method");
     }
 
     fn verifyIfDegenerateAttributesExist(first: f64, second: f64, third: f64) TriangleError!void {
         _ = first;
         _ = second;
         _ = third;
-        @panic("optional verifyIfDegenerateAttributesExist method");
+        @compileError("optional verifyIfDegenerateAttributesExist method");
     }
 
     fn verifyIfTriangleInequalityHolds(first: f64, second: f64, third: f64) TriangleError!void {
         _ = first;
         _ = second;
         _ = third;
-        @panic("please implement the verifyIfTriangleInequalityHolds method");
+        @compileError("please implement the verifyIfTriangleInequalityHolds method");
     }
 
     pub fn isEquilateral(self: Triangle) bool {
         _ = self;
-        @panic("please implement the isEquilateral method");
+        @compileError("please implement the isEquilateral method");
     }
 
     pub fn isIsosceles(self: Triangle) bool {
         _ = self;
-        @panic("please implement the isIsosceles method");
+        @compileError("please implement the isIsosceles method");
     }
 
     pub fn isScalene(self: Triangle) bool {
         _ = self;
-        @panic("please implement the isScalene method");
+        @compileError("please implement the isScalene method");
     }
 };

--- a/exercises/practice/two-fer/two_fer.zig
+++ b/exercises/practice/two-fer/two_fer.zig
@@ -1,5 +1,5 @@
 pub fn twoFer(buffer: []u8, name: ?[]const u8) anyerror![]u8 {
     _ = buffer;
     _ = name;
-    @panic("respond with the appropriate message given a particular name");
+    @compileError("respond with the appropriate message given a particular name");
 }


### PR DESCRIPTION
Before this commit, when running the tests for an exercise with the
unchanged stub:

```console
$ zig test test_leap.zig
Test [1/9] test.year not divisible by 4 in common year... thread 123456 panic: please implement the isLeapYear function
/foo/exercism-tracks/zig/exercises/practice/leap/leap.zig:3:5: 0x20aaaa in isLeapYear (test)
    @panic("please implement the isLeapYear function");
    ^
/foo/exercism-tracks/zig/exercises/practice/leap/test_leap.zig:7:40: 0x20bbbb in test.year not divisible by 4 in common year (test)
    try testing.expect(!leap.isLeapYear(2015));
                                       ^
/usr/lib/zig/lib/test_runner.zig:66:28: 0x20cccc in main (test)
        } else test_fn.func();
                           ^
/usr/lib/zig/lib/std/start.zig:606:22: 0x20dddd in posixCallMainAndExit (test)
            root.main();
                     ^
/usr/lib/zig/lib/std/start.zig:376:5: 0x20eeee in _start (test)
    @call(.never_inline, posixCallMainAndExit, .{});
    ^
error: the following test command crashed:
/foo/.cache/zig/o/01234567890123456789012345678901/test
```

With this commit:

```console
    $ zig test test_leap.zig
    leap.zig:3:5: error: please implement the isLeapYear function
        @compileError("please implement the isLeapYear function");
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    referenced by:
        test.year divisible by 200, not divisible by 400 in common year: test_leap.zig:39:29
        remaining reference traces hidden; use '-freference-trace' to see all reference traces
```

Closes: #176