### PR TITLE
.github: add workflow for `zig fmt`

### DIFF
--- a/.github/workflows/zig-fmt.yml
+++ b/.github/workflows/zig-fmt.yml
@@ -1,0 +1,17 @@
+name: Zig fmt
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  zig-fmt:
+    name: Run `zig fmt`
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+    - name: Install Zig
+      run: ./.github/bin/install-zig.sh
+
+    - name: Check that Zig code is formatted
+      run: |
+        "${HOME}/bin/zig" fmt --check .


### PR DESCRIPTION
Closes: #194

---

```console
$ zig fmt --help
Usage: zig fmt [file]...

   Formats the input files and modifies them in-place.
   Arguments can be files or directories, which are searched
   recursively.

Options:
   -h, --help             Print this help and exit
   --color [auto|off|on]  Enable or disable colored error messages
   --stdin                Format code from stdin; output to stdout
   --check                List non-conforming files and exit with an error
                          if the list is non-empty
   --ast-check            Run zig ast-check on every file
   --exclude [file]       Exclude file or directory from formatting
```