### PR TITLE
docs: add links to ziglings

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -4,7 +4,8 @@
 - [Awesome Zig][awesome-zig] is a good collection of Zig projects made by various people.
   The collection features projects involving well developed Zig code.
 - [ZigLearn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
-- [Ziglings][ziglings] is highly recommended. Learn Zig by fixing tiny broken programs.
+- [Ziglings][ziglings] is highly recommended.
+  Learn Zig by fixing tiny broken programs.
 - [Zig SHOWTIME][zig-showtime] is a livestreamed show where members of the Zig community share code and ideas.
 
 [awesome-zig]: https://github.com/catdevnull/awesome-zig

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -2,7 +2,8 @@
 
 - [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
 - [Zig Learn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
-- [Ziglings][ziglings] is highly recommended. Learn Zig by fixing tiny broken programs.
+- [Ziglings][ziglings] is highly recommended.
+  Learn Zig by fixing tiny broken programs.
 - [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord].
   It provides a great way to get in touch with the Zig community at large, and get some quick, direct help for any Zig related problem.
 - [#zig][irc] on irc.freenode.net is the main Zig IRC channel.


### PR DESCRIPTION
This is one of the two main learning resources mentioned on https://ziglang.org/learn/.

Closes: #186

---

For later: bikeshed the description a bit. We should probably say that it's the suggested thing to do before starting practice exercises on Exercism. It's a bit like a fully fleshed-out set of concept exercises. 