### PR TITLE
config: improve exercise ordering

### DIFF
--- a/config.json
+++ b/config.json
@@ -299,6 +299,26 @@
         "difficulty": 1
       },
       {
+        "uuid": "6eb542c3-c14f-430a-81ce-ba9f2c0551c2",
+        "slug": "queen-attack",
+        "name": "Queen Attack",
+        "practices": [
+          "control-flow",
+          "error-sets",
+          "importing",
+          "methods",
+          "structs"
+        ],
+        "prerequisites": [
+          "control-flow",
+          "error-sets",
+          "importing",
+          "methods",
+          "structs"
+        ],
+        "difficulty": 1
+      },
+      {
         "uuid": "866a09d8-6949-4363-b83f-7b9fefb53893",
         "slug": "two-fer",
         "name": "Two Fer",
@@ -337,26 +357,6 @@
           "error-sets",
           "slices",
           "type-coercion"
-        ],
-        "difficulty": 1
-      },
-      {
-        "uuid": "6eb542c3-c14f-430a-81ce-ba9f2c0551c2",
-        "slug": "queen-attack",
-        "name": "Queen Attack",
-        "practices": [
-          "control-flow",
-          "error-sets",
-          "importing",
-          "methods",
-          "structs"
-        ],
-        "prerequisites": [
-          "control-flow",
-          "error-sets",
-          "importing",
-          "methods",
-          "structs"
         ],
         "difficulty": 1
       },


### PR DESCRIPTION
Before this commit, the exercise order did not provide a gradual introduction to Zig:

```console
$ jq -r '.exercises.practice | .[].slug' < config.json
hello-world
two-fer
resistor-color
resistor-color-duo
difference-of-squares
collatz-conjecture
grains
darts
hamming
leap
triangle
pangram
rna-transcription
space-age
queen-attack
binary-search
secret-handshake
isogram
proverb
armstrong-numbers
```

With this commit, the order is:

```console
$ jq -r '.exercises.practice | .[].slug' < config.json
hello-world
leap
difference-of-squares
collatz-conjecture
pangram
armstrong-numbers
isogram
hamming
grains
resistor-color
resistor-color-duo
darts
triangle
space-age
queen-attack
two-fer
rna-transcription
binary-search
proverb
secret-handshake
```

There are still problems, and gaps to fill, but the new order is a huge improvement. The worst problem before was possibly `two-fer`, which would be a difficult second exercise for a Zig newcomer.

Closes: #177