### PR TITLE
exercises(triangle): simplify error set

### DIFF
--- a/exercises/practice/triangle/.meta/example.zig
+++ b/exercises/practice/triangle/.meta/example.zig
@@ -1,6 +1,5 @@
 pub const TriangleError = error{
-    Degenerate,
-    InvalidInequality,
+    Invalid,
 };
 
 pub const Triangle = struct {
@@ -9,8 +8,7 @@ pub const Triangle = struct {
     c: f64,
 
     pub fn init(a: f64, b: f64, c: f64) TriangleError!Triangle {
-        if ((a + b == c) or (a + c == b) or (b + c == a)) return TriangleError.Degenerate;
-        if ((a + b < c) or (a + c < b) or (b + c < a)) return TriangleError.InvalidInequality;
+        if ((a + b <= c) or (a + c <= b) or (b + c <= a)) return TriangleError.Invalid;
         return Triangle{ .a = a, .b = b, .c = c };
     }
 

--- a/exercises/practice/triangle/test_triangle.zig
+++ b/exercises/practice/triangle/test_triangle.zig
@@ -20,7 +20,7 @@ test "equilateral no sides are equal" {
 
 test "equilateral all zero sides is not a triangle" {
     const actual = triangle.Triangle.init(0, 0, 0);
-    try testing.expectError(triangle.TriangleError.Degenerate, actual);
+    try testing.expectError(triangle.TriangleError.Invalid, actual);
 }
 
 test "equilateral sides may be floats" {
@@ -55,17 +55,17 @@ test "isosceles no sides are equal" {
 
 test "isosceles first triangle inequality violation" {
     const actual = triangle.Triangle.init(1, 1, 3);
-    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.Invalid, actual);
 }
 
 test "isosceles second triangle inequality violation" {
     const actual = triangle.Triangle.init(1, 3, 1);
-    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.Invalid, actual);
 }
 
 test "isosceles third triangle inequality violation" {
     const actual = triangle.Triangle.init(3, 1, 1);
-    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.Invalid, actual);
 }
 
 test "isosceles sides may be floats" {
@@ -100,7 +100,7 @@ test "scalene second and third sides are equal" {
 
 test "scalene may not violate triangle inequality" {
     const actual = triangle.Triangle.init(7, 3, 2);
-    try testing.expectError(triangle.TriangleError.InvalidInequality, actual);
+    try testing.expectError(triangle.TriangleError.Invalid, actual);
 }
 
 test "scalene sides may be floats" {


### PR DESCRIPTION
I took an editing pass of the triangle exercise

* https://github.com/exercism/zig/issues/215 Replaced the `TriangleError.InvalidEquality` with `TriangleError.Invalid`
* ~~https://github.com/exercism/zig/issues/216 Removed private `fn` stubs in the initial code~~ @ee7 is too fast lol
* Misc small refactors to the example

Closes: #215