### PR TITLE
exercises(queen-attack): add stub

### DIFF
--- a/exercises/practice/queen-attack/queen_attack.zig
+++ b/exercises/practice/queen-attack/queen_attack.zig
@@ -1,0 +1,17 @@
+pub const QueenError = error{
+    InitializationFailure,
+};
+
+pub const Queen = struct {
+    pub fn init(x: i8, y: i8) QueenError!Queen {
+        _ = x;
+        _ = y;
+        @compileError("please implement the init method");
+    }
+
+    pub fn canAttack(self: Queen, other: Queen) QueenError!bool {
+        _ = self;
+        _ = other;
+        @compileError("please implement the canAttack method");
+    }
+};


### PR DESCRIPTION
Closes #220 

The error type is included only with `InitializationFailure`, to give minimal API between this and tests.