### PR TITLE
exercises(queen-attack): make stub non-empty

### DIFF
--- a/exercises/practice/queen-attack/queen_attack.zig
+++ b/exercises/practice/queen-attack/queen_attack.zig
@@ -1,0 +1,17 @@
+pub const QueenError = error{
+    InitializationFailure,
+};
+
+pub const Queen = struct {
+    pub fn init(row: i8, col: i8) QueenError!Queen {
+        _ = row;
+        _ = col;
+        @compileError("please implement the init method");
+    }
+
+    pub fn canAttack(self: Queen, other: Queen) QueenError!bool {
+        _ = self;
+        _ = other;
+        @compileError("please implement the canAttack method");
+    }
+};


### PR DESCRIPTION
Using `row` and `col` as the suggested names.

Follow-up to https://github.com/exercism/zig/commit/02707c80bfecf1293e0c67d4c6144b5efc19ff9b.

Closes: #220