### PR TITLE
bin(run-tests): format

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,74 +1,73 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-execute_test () {
-    if [ -d "${1}" ]; then
-        (
-        cd "${1}"
-        # Get the exercise name from the directory
-        EXERCISE_NAME=$(echo "$1" | tr '-' '_')
+execute_test() {
+  if [ -d "${1}" ]; then
+    (
+      cd "${1}"
+      # Get the exercise name from the directory
+      EXERCISE_NAME=$(echo "$1" | tr '-' '_')
 
-        echo "Running tests for ${EXERCISE_NAME}";
+      echo "Running tests for ${EXERCISE_NAME}"
 
-        # Copy the examples with the correct name for the exercise
-        if [ -e "./.meta/example.zig" ]; then
-            mv ./.meta/example.zig "${EXERCISE_NAME}".zig
-            # No building required, just test it
-            if [ -L "${HOME}/bin/zig" ]; then
-                # Zig track repo symlinks zig to this location
-                "${HOME}/bin/zig" test "test_${EXERCISE_NAME}.zig"
-            else
-                # Otherwise zig should be on your $PATH
-                zig test "test_${EXERCISE_NAME}.zig"
-            fi
-            printf '\n'
+      # Copy the examples with the correct name for the exercise
+      if [ -e "./.meta/example.zig" ]; then
+        mv ./.meta/example.zig "${EXERCISE_NAME}".zig
+        # No building required, just test it
+        if [ -L "${HOME}/bin/zig" ]; then
+          # Zig track repo symlinks zig to this location
+          "${HOME}/bin/zig" test "test_${EXERCISE_NAME}.zig"
         else
-            printf '%s\n' \
-                "${EXERCISE_NAME} missing contents, skipping test..."
+          # Otherwise zig should be on your $PATH
+          zig test "test_${EXERCISE_NAME}.zig"
         fi
-        )
-    fi
+        printf '\n'
+      else
+        printf '%s\n' "${EXERCISE_NAME} missing contents, skipping test..."
+      fi
+    )
+  fi
 }
 
 # Move to the root directory of the repo so you can run this script from anywhere
-SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "${SCRIPT_DIR}"/..
 
 # Clear up any previous run
 if [ -d build ]; then
-    rm -rf build
+  rm -rf build
 fi
 
 if [ -d "exercises/practice" ]; then
-    cp -r exercises/practice build
-    cd build/
+  cp -r exercises/practice build
+  cd build/
 else
-    printf '%s\n' "The exercises/practice folder is missing..." >&2
-    exit 1
+  printf '%s\n' "The exercises/practice folder is missing..." >&2
+  exit 1
 fi
 
 # Allow specifying which tests to run as arguments
 if [ $# -gt 0 ]; then
-    for exercise in "$@"; do
-        # Check if the file exists
-        if [ -e "${exercise}" ]; then
-            execute_test "$exercise"
-        else
-            printf '%s\n' "The specified exercise '${exercise}' does not exist" >&2
-            exit 1
-        fi
-    done
+  for exercise in "$@"; do
+    # Check if the file exists
+    if [ -e "${exercise}" ]; then
+      execute_test "$exercise"
+    else
+      printf '%s\n' "The specified exercise '${exercise}' does not exist" >&2
+      exit 1
+    fi
+  done
 else
-    for exercise in *; do
-        # Check if the file exists
-        if [ -e "${exercise}" ]; then
-            execute_test "${exercise}"
-        fi
-    done
+  for exercise in *; do
+    # Check if the file exists
+    if [ -e "${exercise}" ]; then
+      execute_test "${exercise}"
+    fi
+  done
 fi
 
 # Clean up duplicate exercises
 cd ..
 if [ -d build ]; then
-    rm -rf build
+  rm -rf build
 fi


### PR DESCRIPTION
Be consistent with `bin/fetch-configlet`.

Closes: #233

---

Commit the result of running

```shell
shfmt -i 2 -ci -kp -w bin/run-tests .github/bin/install-zig
```

`fetch-configlet` is formatted via `shfmt`.

```console
$ shfmt --help
usage: shfmt [flags] [path ...]

shfmt formats shell programs. If the only argument is a dash ('-') or no
arguments are given, standard input will be used. If a given path is a
directory, all shell scripts found under that directory will be used.

  --version  show version and exit

  -l,  --list      list files whose formatting differs from shfmt's
  -w,  --write     write result to file instead of stdout
  -d,  --diff      error with a diff when the formatting differs
  -s,  --simplify  simplify the code
  -mn, --minify    minify the code to reduce its size (implies -s)

Parser options:

  -ln, --language-dialect str  bash/posix/mksh/bats, default "auto"
  -p,  --posix                 shorthand for -ln=posix
  --filename str               provide a name for the standard input file

Printer options:

  -i,  --indent uint       0 for tabs (default), >0 for number of spaces
  -bn, --binary-next-line  binary ops like && and | may start a line
  -ci, --case-indent       switch cases will be indented
  -sr, --space-redirects   redirect operators will be followed by a space
  -kp, --keep-padding      keep column alignment paddings
  -fn, --func-next-line    function opening braces are placed on a separate line

Utilities:

  -f, --find   recursively find all shell files and print the paths
  --to-json    print syntax tree to stdout as a typed JSON
  --from-json  read syntax tree from stdin as a typed JSON

For more information, see 'man shfmt' and https://github.com/mvdan/sh.
```