### PR TITLE
bin(run-tests): lowercase variable names

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -6,32 +6,32 @@ execute_test() {
     (
       cd "${1}"
       # Get the exercise name from the directory
-      EXERCISE_NAME=$(echo "$1" | tr '-' '_')
+      exercise_name=$(echo "$1" | tr '-' '_')
 
-      echo "Running tests for ${EXERCISE_NAME}"
+      echo "Running tests for ${exercise_name}"
 
       # Copy the examples with the correct name for the exercise
       if [ -e "./.meta/example.zig" ]; then
-        mv ./.meta/example.zig "${EXERCISE_NAME}".zig
+        mv ./.meta/example.zig "${exercise_name}".zig
         # No building required, just test it
         if [ -L "${HOME}/bin/zig" ]; then
           # Zig track repo symlinks zig to this location
-          "${HOME}/bin/zig" test "test_${EXERCISE_NAME}.zig"
+          "${HOME}/bin/zig" test "test_${exercise_name}.zig"
         else
           # Otherwise zig should be on your $PATH
-          zig test "test_${EXERCISE_NAME}.zig"
+          zig test "test_${exercise_name}.zig"
         fi
         printf '\n'
       else
-        printf '%s\n' "${EXERCISE_NAME} missing contents, skipping test..."
+        printf '%s\n' "${exercise_name} missing contents, skipping test..."
       fi
     )
   fi
 }
 
 # Move to the root directory of the repo so you can run this script from anywhere
-SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
-cd "${SCRIPT_DIR}"/..
+script_dir="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+cd "${script_dir}"/..
 
 # Clear up any previous run
 if [ -d build ]; then


### PR DESCRIPTION
Be consistent with the other scripts:

- [`bin/fetch-configlet`](https://github.com/exercism/zig/blob/2b30c5fcdd9e6b4ba1ee1a305076cd7bcac82843/bin/fetch-configlet)
- [`.github/bin/install-zig`](https://github.com/exercism/zig/blob/2b30c5fcdd9e6b4ba1ee1a305076cd7bcac82843/.github/bin/install-zig)

Closes: #234