### PR TITLE
exercises(sieve): example: generate primes at compile time

### DIFF
--- a/exercises/practice/sieve/.meta/example.zig
+++ b/exercises/practice/sieve/.meta/example.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const sqrt = std.math.sqrt;
 
-/// Returns bools, where `result[i]` is `true` iff `i` is a prime number.
+/// Returns bools, where the value at index `i` is `true` iff `i` is a prime number.
 fn eratosthenes(comptime n: u32) []const bool {
     var result = [_]bool{false} ** (n + 1);
     result[2] = true;


### PR DESCRIPTION
Add two functions to reach the same result: baking the prime numbers into the executable at compile time. This PR doesn't change what happens at run time. 

The sieve could produce a bit set rather than an array of bools, but let's keep things relatively simple.