### PR TITLE
exercises(binary-search): example: improve

### DIFF
--- a/exercises/practice/binary-search/.meta/example.zig
+++ b/exercises/practice/binary-search/.meta/example.zig
@@ -10,7 +10,7 @@ pub fn binarySearch(comptime T: type, target: T, buffer: []const T) SearchError!
     var right = buffer.len;
 
     while (left < right) {
-        const mid = left + ((right - left) / 2); // Avoid overflow.
+        const mid = left + (right - left) / 2; // Avoid overflow.
         if (buffer[mid] == target) {
             return mid;
         } else if (buffer[mid] < target) {


### PR DESCRIPTION
Changes:

- Make `buffer` no longer an optional. This means we now never return `SearchError.NullBuffer`, but tere was no test case for it.
- Make the implementation more standard, avoiding possible overflow when calculating `mid`.

I will later PR to make this exercise return `?usize` instead.

Refs: #229 