### PR TITLE
exercises(triangle): return an optional, not an error union

### DIFF
--- a/config.json
+++ b/config.json
@@ -264,6 +264,7 @@
           "error-sets",
           "functions",
           "methods",
+          "optionals",
           "structs"
         ],
         "prerequisites": [
@@ -272,6 +273,7 @@
           "error-sets",
           "functions",
           "methods",
+          "optionals",
           "structs"
         ],
         "difficulty": 1

--- a/exercises/practice/triangle/.meta/example.zig
+++ b/exercises/practice/triangle/.meta/example.zig
@@ -1,14 +1,10 @@
-pub const TriangleError = error{
-    Invalid,
-};
-
 pub const Triangle = struct {
     a: f64,
     b: f64,
     c: f64,
 
-    pub fn init(a: f64, b: f64, c: f64) TriangleError!Triangle {
-        if ((a + b <= c) or (a + c <= b) or (b + c <= a)) return TriangleError.Invalid;
+    pub fn init(a: f64, b: f64, c: f64) ?Triangle {
+        if ((a + b <= c) or (a + c <= b) or (b + c <= a)) return null;
         return Triangle{ .a = a, .b = b, .c = c };
     }
 

--- a/exercises/practice/triangle/test_triangle.zig
+++ b/exercises/practice/triangle/test_triangle.zig
@@ -4,106 +4,106 @@ const testing = std.testing;
 const triangle = @import("triangle.zig");
 
 test "equilateral all sides are equal" {
-    const actual = try triangle.Triangle.init(2, 2, 2);
-    try testing.expect(actual.isEquilateral());
+    const actual = triangle.Triangle.init(2, 2, 2);
+    try testing.expect(actual.?.isEquilateral());
 }
 
 test "equilateral any side is unequal" {
-    const actual = try triangle.Triangle.init(2, 3, 2);
-    try testing.expect(!actual.isEquilateral());
+    const actual = triangle.Triangle.init(2, 3, 2);
+    try testing.expect(!actual.?.isEquilateral());
 }
 
 test "equilateral no sides are equal" {
-    const actual = try triangle.Triangle.init(5, 4, 6);
-    try testing.expect(!actual.isEquilateral());
+    const actual = triangle.Triangle.init(5, 4, 6);
+    try testing.expect(!actual.?.isEquilateral());
 }
 
 test "equilateral all zero sides is not a triangle" {
     const actual = triangle.Triangle.init(0, 0, 0);
-    try testing.expectError(triangle.TriangleError.Invalid, actual);
+    try testing.expect(actual == null);
 }
 
 test "equilateral sides may be floats" {
-    const actual = try triangle.Triangle.init(0.5, 0.5, 0.5);
-    try testing.expect(actual.isEquilateral());
+    const actual = triangle.Triangle.init(0.5, 0.5, 0.5);
+    try testing.expect(actual.?.isEquilateral());
 }
 
 test "isosceles last two sides are equal" {
-    const actual = try triangle.Triangle.init(3, 4, 4);
-    try testing.expect(actual.isIsosceles());
+    const actual = triangle.Triangle.init(3, 4, 4);
+    try testing.expect(actual.?.isIsosceles());
 }
 
 test "isosceles first two sides are equal" {
-    const actual = try triangle.Triangle.init(4, 4, 3);
-    try testing.expect(actual.isIsosceles());
+    const actual = triangle.Triangle.init(4, 4, 3);
+    try testing.expect(actual.?.isIsosceles());
 }
 
 test "isosceles first and last sides are equal" {
-    const actual = try triangle.Triangle.init(4, 3, 4);
-    try testing.expect(actual.isIsosceles());
+    const actual = triangle.Triangle.init(4, 3, 4);
+    try testing.expect(actual.?.isIsosceles());
 }
 
 test "equilateral triangles are also isosceles" {
-    const actual = try triangle.Triangle.init(4, 3, 4);
-    try testing.expect(actual.isIsosceles());
+    const actual = triangle.Triangle.init(4, 3, 4);
+    try testing.expect(actual.?.isIsosceles());
 }
 
 test "isosceles no sides are equal" {
-    const actual = try triangle.Triangle.init(2, 3, 4);
-    try testing.expect(!actual.isIsosceles());
+    const actual = triangle.Triangle.init(2, 3, 4);
+    try testing.expect(!actual.?.isIsosceles());
 }
 
 test "isosceles first triangle inequality violation" {
     const actual = triangle.Triangle.init(1, 1, 3);
-    try testing.expectError(triangle.TriangleError.Invalid, actual);
+    try testing.expect(actual == null);
 }
 
 test "isosceles second triangle inequality violation" {
     const actual = triangle.Triangle.init(1, 3, 1);
-    try testing.expectError(triangle.TriangleError.Invalid, actual);
+    try testing.expect(actual == null);
 }
 
 test "isosceles third triangle inequality violation" {
     const actual = triangle.Triangle.init(3, 1, 1);
-    try testing.expectError(triangle.TriangleError.Invalid, actual);
+    try testing.expect(actual == null);
 }
 
 test "isosceles sides may be floats" {
-    const actual = try triangle.Triangle.init(0.5, 0.4, 0.5);
-    try testing.expect(actual.isIsosceles());
+    const actual = triangle.Triangle.init(0.5, 0.4, 0.5);
+    try testing.expect(actual.?.isIsosceles());
 }
 
 test "scalene no sides are equal" {
-    const actual = try triangle.Triangle.init(5, 4, 6);
-    try testing.expect(actual.isScalene());
+    const actual = triangle.Triangle.init(5, 4, 6);
+    try testing.expect(actual.?.isScalene());
 }
 
 test "scalene all sides are equal" {
-    const actual = try triangle.Triangle.init(4, 4, 4);
-    try testing.expect(!actual.isScalene());
+    const actual = triangle.Triangle.init(4, 4, 4);
+    try testing.expect(!actual.?.isScalene());
 }
 
 test "scalene first and second sides are equal" {
-    const actual = try triangle.Triangle.init(4, 4, 3);
-    try testing.expect(!actual.isScalene());
+    const actual = triangle.Triangle.init(4, 4, 3);
+    try testing.expect(!actual.?.isScalene());
 }
 
 test "scalene first and third sides are equal" {
-    const actual = try triangle.Triangle.init(3, 4, 3);
-    try testing.expect(!actual.isScalene());
+    const actual = triangle.Triangle.init(3, 4, 3);
+    try testing.expect(!actual.?.isScalene());
 }
 
 test "scalene second and third sides are equal" {
-    const actual = try triangle.Triangle.init(4, 3, 3);
-    try testing.expect(!actual.isScalene());
+    const actual = triangle.Triangle.init(4, 3, 3);
+    try testing.expect(!actual.?.isScalene());
 }
 
 test "scalene may not violate triangle inequality" {
     const actual = triangle.Triangle.init(7, 3, 2);
-    try testing.expectError(triangle.TriangleError.Invalid, actual);
+    try testing.expect(actual == null);
 }
 
 test "scalene sides may be floats" {
-    const actual = try triangle.Triangle.init(0.5, 0.4, 0.6);
-    try testing.expect(actual.isScalene());
+    const actual = triangle.Triangle.init(0.5, 0.4, 0.6);
+    try testing.expect(actual.?.isScalene());
 }

--- a/exercises/practice/triangle/triangle.zig
+++ b/exercises/practice/triangle/triangle.zig
@@ -1,7 +1,7 @@
 pub const Triangle = struct {
     // This struct, as well as its fields and methods, needs to be implemented.
 
-    pub fn init(a: f64, b: f64, c: f64) TriangleError!Triangle {
+    pub fn init(a: f64, b: f64, c: f64) ?Triangle {
         _ = a;
         _ = b;
         _ = c;


### PR DESCRIPTION
We simplified the error set to contain only one error (4a4665a4dbeb), so there's an argument to use an optional instead.

Refs: #229

---

Thoughts on whether this is an improvement? I'm not convinced for this particular exercise. Basically, if you call `init` with some strange side lengths, do you want an error or `null`?

I'll did this to see what it'd look like as `null`, but I'm leaning towards closing this PR. We can reopen it if we feel it's worth considering.