### PR TITLE
bump Zig from 0.10.1 to 0.11.0

### DIFF
--- a/.github/bin/install-zig
+++ b/.github/bin/install-zig
@@ -18,7 +18,7 @@ esac
 
 arch="$(uname -m)"
 
-version='0.10.1'
+version='0.11.0'
 url="https://ziglang.org/download/${version}/zig-${os}-${arch}-${version}.${ext}"
 
 curlopts=(

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -4,13 +4,4 @@
 
 It may be helpful to look at the implementation of [`std.enums.EnumSet`][enumset].
 
-### Compatibility
-
-The development version of Zig contains [new `EnumSet` functions][new-enumset-functions], but Exercism currently uses Zig 0.10.1 (the latest release) to run the tests.
-
-Therefore, for example, a correct solution that uses the new `initEmpty()` will fail the tests on Exercism (at least until Zig 0.11.0 is released).
-Sorry.
-You don't need those functions for this exercise, though.
-
-[enumset]: https://github.com/ziglang/zig/blob/0.10.1/lib/std/enums.zig#L220-L246
-[new-enumset-functions]: https://github.com/ziglang/zig/commit/a792e13fc08982e79cb1b08d14322be76b8cf77a
+[enumset]: https://github.com/ziglang/zig/blob/0.11.0/lib/std/enums.zig#L236-L262

--- a/exercises/practice/perfect-numbers/.docs/instructions.append.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.append.md
@@ -8,6 +8,6 @@ For more details, see the [Zig Language Reference][zig-reference] and the implem
 
 However, note that this exercise does not currently test an input of 0 (because `std.testing` does [not yet support expecting a panic][proposal]).
 
-[zig-reference]: https://ziglang.org/documentation/0.10.1/#unreachable
-[assert]: https://github.com/ziglang/zig/blob/0.10.1/lib/std/debug.zig#L267-L279
+[zig-reference]: https://ziglang.org/documentation/0.11.0/#unreachable
+[assert]: https://github.com/ziglang/zig/blob/0.11.0/lib/std/debug.zig#L332-L344
 [proposal]: https://github.com/ziglang/zig/issues/1356


### PR DESCRIPTION
zig 0.11.0 isn't quite released yet, so CI will fail. Apparently the tarballs will finish building in about 6 hours.

Before merging this we'll also need to:

- [ ] Update exercises as needed.
- [ ] Ensure that the corresponding PR in the test runner repo works, so we can bump in both repos near-simultaneously.

---

See the [release notes][1].

Refs: https://github.com/exercism/zig/issues/244

[1]: https://ziglang.org/download/0.11.0/release-notes.html
