### PR TITLE
.github(org-wide-files-config): enable `configlet fmt`

### DIFF
--- a/.github/org-wide-files-config.toml
+++ b/.github/org-wide-files-config.toml
@@ -1,0 +1,2 @@
+[configlet]
+fmt = true


### PR DESCRIPTION
When syncing the configlet workflow, @exercism-bot created a PR to disable our `configlet fmt` CI check. Tell the bot that we want that check.

Follow-up from https://github.com/exercism/nim/pull/528#issuecomment-1674345444