### PR TITLE
bin(run-tests): refactor

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -9,7 +9,7 @@ execute_test() {
     local exercise_name
     exercise_name=$(echo "$1" | tr '-' '_')
 
-    echo "Running tests for ${exercise_name}"
+    printf '%s\n' "Running tests for ${exercise_name}"
 
     # Copy the examples with the correct name for the exercise
     if [[ -f "./.meta/example.zig" ]]; then


### PR DESCRIPTION
Make the `run-tests` script more readable (at least for my taste), and more consistent with the style in `bin/fetch-configlet`.

This is just refactoring - no change in functionality. But we exchange some theoretical TOCTOU subtleties for other ones. See individual commits for more details. A whitespace-ignoring or whitespace-aware diff is more readable here.

Summary:

- Move zig detection out of the loop. We don't need to support moving the zig installation while the script is executing.
- Prefer `[[` to `[` for bash. See e.g. [this section][1] in the Google Shell Style Guide.
- Add a main function, and declare variables as `local`. This is also suggested ([here][2] and [here][3]) in the same guide, and matches `bin/fetch-configlet`.
- Prefer `-f` and `-d` to `-e`.
- Remove some unnecessary directory existence checks.
- Use `printf` more consistently.

[1]: https://google.github.io/styleguide/shellguide.html#s6.3-tests
[2]: https://google.github.io/styleguide/shellguide.html#main
[3]: https://google.github.io/styleguide/shellguide.html#s7.6-use-local-variables
