### PR TITLE
bin(run-tests): improve status messages

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -8,14 +8,14 @@ execute_test() {
     local exercise_name
     exercise_name=$(echo "$1" | tr '-' '_')
 
-    printf '%s\n' "Running tests for ${1}..."
+    printf '%s\n' "Running tests for ${1}..." >&2
 
     # Copy the examples with the correct name for the exercise
     if [[ -f "./.meta/example.zig" ]]; then
       mv ./.meta/example.zig "${exercise_name}".zig
       # No building required, just test it
       zig test "test_${exercise_name}.zig"
-      printf '\n'
+      printf '\n' >&2
     else
       printf '%s\n' "Error: ${exercise_name} lacks its '.meta/example.zig' file" >&2
       exit 1


### PR DESCRIPTION
Trivial improvements. 

Changes:

- Print the exercise name in its canonical `kebab-case` form, not its `snake_case` form.
- Improve ellipsis usage.
- Prefix error messages with Error, being consistent with the style in 7ff0372113a8.
- Add quotes around a path.
- Consistently use "directory", not "folder".
- Consistently write status messages to stderr.

Note that the `zig test` output goes to stderr. Before this commit:

```console
$ bin/run-tests > /dev/null
All 9 tests passed.
All 50 tests passed.
All 13 tests passed.
[...]
```

With this commit:

```console
$ bin/run-tests > /dev/null
Running tests for acronym...
All 9 tests passed.

Running tests for allergies...
All 50 tests passed.

Running tests for armstrong-numbers...
All 13 tests passed.

[...]
```