### PR TITLE
test_rna_transcription: don't leak memory when answer differs.

### DIFF
--- a/exercises/practice/rna-transcription/test_rna_transcription.zig
+++ b/exercises/practice/rna-transcription/test_rna_transcription.zig
@@ -7,8 +7,8 @@ const RnaError = rna_transcription.RnaError;
 
 fn testTranscription(dna: []const u8, expected: []const u8) !void {
     const rna = try rna_transcription.toRna(testing.allocator, dna);
+    defer testing.allocator.free(rna);
     try testing.expectEqualStrings(expected, rna);
-    testing.allocator.free(rna);
 }
 
 test "empty rna sequence" {


### PR DESCRIPTION
Spent so much time trying to understand why I have memory leak, which turned out to be memory leak in testing code =)