### PR TITLE
test_all_your_base.zig memory leak fix

### DIFF
--- a/exercises/practice/all-your-base/test_all_your_base.zig
+++ b/exercises/practice/all-your-base/test_all_your_base.zig
@@ -91,6 +91,7 @@ test "empty list" {
     const input_base = 2;
     const output_base = 10;
     const actual = try convert(testing.allocator, &digits, input_base, output_base);
+    defer testing.allocator.free(actual);
     try testing.expectEqualSlices(u32, &expected, actual);
 }
 
@@ -100,6 +101,7 @@ test "single zero" {
     const input_base = 10;
     const output_base = 2;
     const actual = try convert(testing.allocator, &digits, input_base, output_base);
+    defer testing.allocator.free(actual);
     try testing.expectEqualSlices(u32, &expected, actual);
 }
 
@@ -109,6 +111,7 @@ test "multiple zeros" {
     const input_base = 10;
     const output_base = 2;
     const actual = try convert(testing.allocator, &digits, input_base, output_base);
+    defer testing.allocator.free(actual);
     try testing.expectEqualSlices(u32, &expected, actual);
 }
 


### PR DESCRIPTION
The comment in user code says:
```
/// Caller owns the returned memory.
```

However, the testing code does not free returned memory if the answer is zero = {0}. As the result, users get memory leaks with wrong code due to testing code breaking the contract. Some awful hacks are necessary to workaround it.