### PR TITLE
exercises(all-your-base): test: add test for global array

### DIFF
--- a/exercises/practice/all-your-base/test_all_your_base.zig
+++ b/exercises/practice/all-your-base/test_all_your_base.zig
@@ -90,7 +90,7 @@ test "empty list - second call returns different memory" {
     // `convert` must always return memory that can be freed.
     // Test that `convert` does not return a slice that references a global array.
     const expected = [_]u32{0};
-    const digits = [_]u32{0};
+    const digits = [_]u32{};
     const input_base = 10;
     const output_base = 2;
     const actual = try convert(testing.allocator, &digits, input_base, output_base);


### PR DESCRIPTION
Follow-up from https://github.com/exercism/zig/pull/317#issuecomment-1717117632.

---

Commit b65162fc0e14914b873b902fb60ca042b3da31c9 added missing frees in the test cases that returned a single 0. This causes a previously-passing solution that incorrectly returned a reference to a global array to panic:

```text
$ zig test test_all_your_base.zig
Test [9/17] test.empty list... thread 27369 panic: Invalid free
/usr/lib/zig/std/heap/general_purpose_allocator.zig:609:21: 0x22cb5e in freeLarge (test)
                    @panic("Invalid free");
                    ^
/usr/lib/zig/std/heap/general_purpose_allocator.zig:824:31: 0x22c0db in free (test)
                self.freeLarge(old_mem, log2_old_align, ret_addr);
                              ^
/usr/lib/zig/std/mem/Allocator.zig:98:28: 0x22800f in free__anon_3776 (test)
    return self.vtable.free(self.ptr, buf, log2_buf_align, ret_addr);
                           ^
/home/foo/exercism-zig/exercises/practice/all-your-base/test_all_your_base.zig:94:33: 0x22881a in test.empty list (test)
    defer testing.allocator.free(actual);
                                ^
```

Add a targeted test case to help a user that writes such a solution. Their solution will still produce a panic, but it will point to a more obvious test case. And it will now produce a test failure first:

```text
$ zig test test_all_your_base.zig
Test [9/18] test.empty list - second call returns different memory... slices differ. first difference occurs at index 0 (0x0)

============ expected this output: =============  len: 1 (0x1)

[0]: 0

============= instead found this: ==============  len: 1 (0x1)

[0]: 1

================================================

thread 27306 panic: Invalid free
/usr/lib/zig/std/heap/general_purpose_allocator.zig:609:21: 0x22ceee in freeLarge (test)
                    @panic("Invalid free");
                    ^
/usr/lib/zig/std/heap/general_purpose_allocator.zig:824:31: 0x22c46b in free (test)
                self.freeLarge(old_mem, log2_old_align, ret_addr);
                              ^
/usr/lib/zig/std/mem/Allocator.zig:98:28: 0x2280df in free__anon_3777 (test)
    return self.vtable.free(self.ptr, buf, log2_buf_align, ret_addr);
                           ^
/home/foo/exercism-zig/exercises/practice/all-your-base/test_all_your_base.zig:101:33: 0x228a3e in test.empty list - second call returns different memory (test)
    defer testing.allocator.free(again);
                                ^
```

The ordering of the test cases looks strange: the test that calls `convert` twice with empty `digits` is before the test that does so once. But otherwise the user will see the panic in the non-targeted test case.