### PR TITLE
config(atbash-cipher): make exercise name Title Case

### DIFF
--- a/config.json
+++ b/config.json
@@ -486,7 +486,7 @@
       {
         "uuid": "0e524507-7144-400e-a0c4-da150a4a2604",
         "slug": "atbash-cipher",
-        "name": "Atbash cipher",
+        "name": "Atbash Cipher",
         "practices": [
           "allocators",
           "strings"


### PR DESCRIPTION
The spec [says][1]:

>The `"exercises.practice[].name"` value must be a Title Case string with length <= 255

[1]: https://github.com/exercism/docs/blob/cbb4653bc933/building/configlet/lint.md

---

Follow up from https://github.com/exercism/zig/commit/54af07f719fae804eae0659f8c83acf761d8d885.