### PR TITLE
exercises(grains): assert, rather than returning error union

### DIFF
--- a/config.json
+++ b/config.json
@@ -190,17 +190,17 @@
         "slug": "grains",
         "name": "Grains",
         "practices": [
+          "asserting",
           "bitwise-operations",
           "builtin-functions",
           "conditionals",
-          "error-sets",
           "functions"
         ],
         "prerequisites": [
+          "asserting",
           "bitwise-operations",
           "builtin-functions",
           "conditionals",
-          "error-sets",
           "functions"
         ],
         "difficulty": 1

--- a/exercises/practice/grains/.meta/example.zig
+++ b/exercises/practice/grains/.meta/example.zig
@@ -1,12 +1,8 @@
 const std = @import("std");
 
-pub const ChessboardError = error{IndexOutOfBounds};
-
-pub fn square(index: u7) ChessboardError!u64 {
-    const number_of_chess_squares = 64;
-    if (index > number_of_chess_squares or index == 0) {
-        return ChessboardError.IndexOutOfBounds;
-    }
+/// Asserts that `index` is greater than 0 and less than 65.
+pub fn square(index: u7) u64 {
+    std.debug.assert(index > 0 and index < 65);
     return @as(u64, 1) << @as(u6, @truncate(index - 1));
 }
 

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -32,6 +32,7 @@ description = "returns the number of grains on the square -> grains on square 64
 
 [1d47d832-3e85-4974-9466-5bd35af484e3]
 description = "returns the number of grains on the square -> square 0 raises an exception"
+include = false
 
 [61974483-eeb2-465e-be54-ca5dde366453]
 description = "returns the number of grains on the square -> negative square raises an exception"
@@ -39,6 +40,7 @@ include = false
 
 [a95e4374-f32c-45a7-a10d-ffec475c012f]
 description = "returns the number of grains on the square -> square greater than 64 raises an exception"
+include = false
 
 [6eb07385-3659-4b45-a6be-9dc474222750]
 description = "returns the total number of grains on the board"

--- a/exercises/practice/grains/grains.zig
+++ b/exercises/practice/grains/grains.zig
@@ -1,4 +1,5 @@
-pub fn square(index: usize) ChessboardError!u64 {
+/// Asserts that `index` is greater than 0 and less than 65.
+pub fn square(index: usize) u64 {
     _ = index;
     @compileError("please implement the square function");
 }

--- a/exercises/practice/grains/test_grains.zig
+++ b/exercises/practice/grains/test_grains.zig
@@ -2,60 +2,47 @@ const std = @import("std");
 const testing = std.testing;
 
 const grains = @import("grains.zig");
-const ChessboardError = grains.ChessboardError;
 
 test "grains on square 1" {
     const expected: u64 = 1;
-    const actual = try grains.square(1);
+    const actual = grains.square(1);
     try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 2" {
     const expected: u64 = 2;
-    const actual = try grains.square(2);
+    const actual = grains.square(2);
     try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 3" {
     const expected: u64 = 4;
-    const actual = try grains.square(3);
+    const actual = grains.square(3);
     try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 4" {
     const expected: u64 = 8;
-    const actual = try grains.square(4);
+    const actual = grains.square(4);
     try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 16" {
     const expected: u64 = 32_768;
-    const actual = try grains.square(16);
+    const actual = grains.square(16);
     try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 32" {
     const expected: u64 = 2_147_483_648;
-    const actual = try grains.square(32);
+    const actual = grains.square(32);
     try testing.expectEqual(expected, actual);
 }
 
 test "grains on square 64" {
     const expected: u64 = 9_223_372_036_854_775_808;
-    const actual = try grains.square(64);
+    const actual = grains.square(64);
     try testing.expectEqual(expected, actual);
-}
-
-test "square 0 produces an error" {
-    const expected = ChessboardError.IndexOutOfBounds;
-    const actual = grains.square(0);
-    try testing.expectError(expected, actual);
-}
-
-test "square greater than 64 produces an error" {
-    const expected = ChessboardError.IndexOutOfBounds;
-    const actual = grains.square(65);
-    try testing.expectError(expected, actual);
 }
 
 test "returns the total number of grains on the board" {


### PR DESCRIPTION
I think that returning an error union here isn't particularly interesting. I think most of the exercises that currently contain (or previously contained) a single-item error set are better if the relevant functions return an optional, or say that it is the caller's responsibility to do input validation.

This PR is a follow-up to https://github.com/exercism/zig/commit/290e7f31ea8a521752885c94c4e771398191dfae, which removed the negative input test case.

Note that we should be able to add the "bad input" tests again in the future - Zig plans to give `std.testing` the ability to expect a panic.

Merging this PR will break everybody's solution.

Refs: #229

Similar to #335 

---

To-do:

- [ ] Check whether we should add an `.append` file that explains how to `assert`