### PR TITLE
.github(dependabot): change interval from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,5 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      time: '05:00'


### PR DESCRIPTION
Rationale:

- I'd prefer to get low-priority dependabot notifications only once per month, rather than potentially any time of any day. I do actually review them - I don't blindly merge.
- This decreases churn and the total number of dependabot PRs, because dependencies are sometimes bumped more than once a month.
- When the bump is not security-critical, it's good to wait a little in case there are problems with the new version that require a quick follow-up release.
- [dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) ignore the interval anyway.
- This repo does not build some user-facing asset, so the drawbacks of slower updates to our GitHub Actions dependencies are minimal.
- If there's some dependency that we need bumped faster, then we can always do it manually (or tell dependabot to create a PR).
- I already set the interval to monthly in some other Exercism repos that I touch, e.g. [configlet](https://github.com/exercism/configlet/blob/95833aca8dcf6602d2cf4a4118ee01c9b6e9e59d/.github/dependabot.yml) and [nim-test-runner](https://github.com/exercism/nim-test-runner/blob/72037075eef1f6399746337d87eb412777168f6a/.github/dependabot.yml), and it helps.

The actions that we currently use in this repo:

```console
$ git grep 'uses:' -- '.github/workflows/*yml' | cut -d':' -f4 | sort | uniq
actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
DavidAnson/markdownlint-cli2-action@ed4dec634fd2ef689c7061d5647371d8248064f1
exercism/github-actions/.github/workflows/community-contributions.yml@main
exercism/github-actions/.github/workflows/configlet.yml@main
exercism/github-actions/.github/workflows/labels.yml@main
```