### PR TITLE
.github(dependabot): specify commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     schedule:
       interval: 'monthly'
       time: '05:00'
+    commit-message:
+      prefix: '.github'


### PR DESCRIPTION
Before this PR, dependabot always prefixed commit messages (and PR titles) with

```text
build(deps):
```

despite claiming that it tries to use the repo style, and there being exactly zero commits titles in this repo that even contain "build" at all.

Instead, make dependabot prefix with the repo style:

```
.github:
```