### PR TITLE
excersises(yacht): add order-independence tests to full-house and four-of-a-kind

### DIFF
--- a/exercises/practice/yacht/test_yacht.zig
+++ b/exercises/practice/yacht/test_yacht.zig
@@ -75,9 +75,21 @@ test "full house two small, three big" {
     try testing.expectEqual(expected, actual);
 }
 
+test "full house two small, three big, alternative order" {
+    const expected: u32 = 14;
+    const actual = score([_]u3{ 4, 4, 2, 2, 2 }, .full_house);
+    try testing.expectEqual(expected, actual);
+}
+
 test "full house three small, two big" {
     const expected: u32 = 19;
     const actual = score([_]u3{ 5, 3, 3, 5, 3 }, .full_house);
+    try testing.expectEqual(expected, actual);
+}
+
+test "full house three small, two big, alternative order" {
+    const expected: u32 = 21;
+    const actual = score([_]u3{ 3, 5, 5, 3, 5 }, .full_house);
     try testing.expectEqual(expected, actual);
 }
 
@@ -102,6 +114,12 @@ test "yacht is not a full house" {
 test "four of a kind" {
     const expected: u32 = 24;
     const actual = score([_]u3{ 6, 6, 4, 6, 6 }, .four_of_a_kind);
+    try testing.expectEqual(expected, actual);
+}
+
+test "four of a kind alternative order" {
+    const expected: u32 = 16;
+    const actual = score([_]u3{ 4, 4, 6, 4, 4 }, .four_of_a_kind);
     try testing.expectEqual(expected, actual);
 }
 


### PR DESCRIPTION
Existing code only tested cases when dice in full-house and four-of-a-kind categories would have groups in certain positions when sorted. For example:

```
3,3,3,3,5 => four of a kind
3,3,3,5,5 => full house
```
but there were no tests for these cases
```
3,5,5,5,5 => four of a kind
3,3,5,5,5 => full house
```
I.e. the cases where group positions and lengths are switched around and a group with smaller number of elements goes first.

I saw several solutions which were hardcoding checks like

```c
if (sorted[0] == sorted[3]) {
  // assume success in detecting four-of a kind
}
```
which is not correct, because it would fail in the `3,5,5,5,5` case while it shouldn't.

This PR adds a few more tests to check alternative ordering.

Not really sure if the new test case naming is good, a bit too vague, was out of ideas on how to name them correctly while staying compact.