### PR TITLE
exercises: docs: fix admonitions

### DIFF
--- a/exercises/practice/binary-search/.docs/instructions.md
+++ b/exercises/practice/binary-search/.docs/instructions.md
@@ -7,7 +7,7 @@ It allows us to quickly narrow down the possible locations of our item until we 
 
 ~~~~exercism/caution
 Binary search only works when a list has been sorted.
-```
+~~~~
 
 The algorithm looks like this:
 

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -13,4 +13,4 @@ Pangram comes from Greek, παν γράμμα, pan gramma, which means "every le
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/rna-transcription/.docs/instructions.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.md
@@ -17,4 +17,4 @@ Given a DNA strand, its transcribed RNA strand is formed by replacing each nucle
 
 ~~~~exercism/note
 If you want to look at how the inputs and outputs are structured, take a look at the examples in the test suite.
-```
+~~~~

--- a/exercises/practice/rna-transcription/.docs/introduction.md
+++ b/exercises/practice/rna-transcription/.docs/introduction.md
@@ -13,4 +13,4 @@ But if you can create a very specific molecule (called a micro-RNA), it can prev
 This technique is called [RNA Interference][rnai].
 
 [rnai]: https://admin.acceleratingscience.com/ask-a-scientist/what-is-rnai/
-```
+~~~~

--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -45,4 +45,4 @@ jump, double blink
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
 
 [intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
-```
+~~~~

--- a/exercises/practice/sieve/.docs/instructions.md
+++ b/exercises/practice/sieve/.docs/instructions.md
@@ -25,4 +25,4 @@ The tests don't check that you've implemented the algorithm, only that you've co
 A good first test is to check that you do not use division or remainder operations.
 
 [eratosthenes]: https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
-```
+~~~~


### PR DESCRIPTION
Commit 3369e5e3acf1 tried to change admonitions back to tildes, but was incomplete.

---

That'll teach me for doing it without waiting for upstream and using `configlet sync`.

Almost all of these admonitions are at the end of the markdown file, so this wasn't _that_ bad. But the admonition for `binary-search` isn't at the end, which means that it renders the later content inside the admonition.

With this PR:

```console
$ git rev-parse --short HEAD
7af8825
$ bin/configlet --version
4.0.0-beta.16
$ bin/configlet sync
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] docs: instructions unsynced: sum-of-multiples
[warn] docs: introduction missing: sum-of-multiples
[warn] some exercises have unsynced docs
```