### PR TITLE
exercises(darts): example: remove unnecessary Self

### DIFF
--- a/exercises/practice/darts/.meta/example.zig
+++ b/exercises/practice/darts/.meta/example.zig
@@ -1,14 +1,12 @@
 pub const Coordinate = struct {
-    const Self = @This();
-
     x: f32,
     y: f32,
 
-    pub fn init(x: f32, y: f32) Self {
+    pub fn init(x: f32, y: f32) Coordinate {
         return .{ .x = x, .y = y };
     }
 
-    pub fn score(self: Self) u32 {
+    pub fn score(self: Coordinate) u32 {
         const n = (self.x * self.x) + (self.y * self.y); // The distance squared.
         return if (n <= 1) 10 else if (n <= 25) 5 else if (n <= 100) 1 else 0;
     }


### PR DESCRIPTION
Use the [preferred style][1].

The only other `@This()` in this repo is in the example solution for the `linked-list` exercise, where it's more appropriate:

https://github.com/exercism/zig/blob/0c4ff7af2ea2da97f68eaba3c20e47a24759857e/exercises/practice/linked-list/.meta/example.zig#L1-L4

[1]: https://zig.news/kristoff/dont-self-simple-structs-fj8

Refs: #313