### PR TITLE
Add test case: non-alphanumeric printable ASCII

### DIFF
--- a/exercises/practice/pangram/test_pangram.zig
+++ b/exercises/practice/pangram/test_pangram.zig
@@ -42,3 +42,7 @@ test "mixed case and punctuation" {
 test "a-m and A-M are 26 different characters but not a pangram" {
     try testing.expect(!pangram.isPangram("abcdefghijklm ABCDEFGHIJKLM"));
 }
+
+test "non-alphanumeric printable ASCII" {
+    try testing.expect(!pangram.isPangram(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"));
+}


### PR DESCRIPTION
This test checks that the submitted solution does not panic on non-alphanumeric input.

Faulty solution 'from the wild' that is caught by this test but not by the others:

```zig
pub fn isPangram(str: []const u8) bool {
    var seen = std.bit_set.StaticBitSet('z' - 'a' + 1).initEmpty();
    for (str) |c| {
        const index = std.math.sub(u8, std.ascii.toLower(c), 'a') catch continue;
        // if  c > 'z'  then  index > 25  😱
        seen.set(index);  // panics when  index >= 26
    }
    return ~seen.mask == 0;
}
```

There are no test cases in `problem-specifications` that could be pulled in to the same effect. I will not myself pursue upstreaming into `problem-specifications`.