### PR TITLE
exercises(linked-list): fix the compiler warning

### DIFF
--- a/exercises/practice/linked-list/test_linked_list.zig
+++ b/exercises/practice/linked-list/test_linked_list.zig
@@ -68,7 +68,7 @@ test "pop, push, shift, and unshift can be used in any order" {
 }
 
 test "count an empty list" {
-    var list = List{};
+    const list = List{};
     try testing.expectEqual(@as(usize, 0), list.len);
 }
 


### PR DESCRIPTION
Fix the following compiler warning when doing the practice in the CLI.
> version: zig-v0.12.0-dev.2059+42389cb9c

```shell
linked-list/test_linked_list.zig:71:9: error: local variable is never mutated
    var list = List{};
        ^~~~
```