### PR TITLE
exercises(collatz-conjecture): clarify requirement to add error

### DIFF
--- a/exercises/practice/collatz-conjecture/.docs/instructions.append.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.append.md
@@ -1,0 +1,20 @@
+# Instructions append
+
+## Error handling
+
+For this exercise you must add an error set `ComputationError` that contains the `IllegalArgument` error.
+Remember to make it public!
+The `steps` function must return `ComputationError.IllegalArgument` when its input is equal to zero.
+
+Later exercises will usually omit explicit instructions like this.
+In general, Exercism expects you to read the test file when implementing your solution.
+
+For more details about errors in Zig, see:
+
+- [Learning Zig - Errors][learning-zig-errors]
+- [Ziglings - Exercise 21][ziglings-exercise-21]
+- [Zighelp - Errors][zighelp-errors]
+
+[learning-zig-errors]: https://www.openmymind.net/learning_zig/language_overview_2/#errors
+[zighelp-errors]: https://zighelp.org/chapter-1/#errors
+[ziglings-exercise-21]: https://codeberg.org/ziglings/exercises/src/commit/0d46acfa02d0c29fdfb3651e82a77284dd8f2e00/exercises/021_errors.zig

--- a/exercises/practice/collatz-conjecture/collatz_conjecture.zig
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture.zig
@@ -1,3 +1,5 @@
+// Please implement the `ComputationError.IllegalArgument` error.
+
 pub fn steps(number: usize) anyerror!usize {
     _ = number;
     @compileError("please implement the steps function");


### PR DESCRIPTION
Closes: #364

---

Alternative to https://github.com/exercism/zig/pull/360 and https://github.com/exercism/zig/pull/363.

It seems like many people are having problems here:

- https://forum.exercism.org/t/error-in-test-for-zig-track-hamming/8406
- https://forum.exercism.org/t/fix-instructions-for-zig-collatz-conjecture/8507