### PR TITLE
.github(no-important-files-changed): add GitHub token

### DIFF
--- a/.github/workflows/no-important-files-changed.yml
+++ b/.github/workflows/no-important-files-changed.yml
@@ -57,6 +57,7 @@ jobs:
         if: steps.check.outputs.important_files_changed == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
+          github-token: ${{ github.token }}
           script: |
             const body = "This PR touches files which potentially affect the outcome of the tests of an exercise. This will cause all students' solutions to affected exercises to be re-tested.\n\nIf this PR does **not** affect the result of the test (or, for example, adds an edge case that is not worth rerunning all tests for), **please add the following to the merge-commit message** which will stops student's tests from re-running. Please copy-paste to avoid typos.\n```\n[no important files changed]\n```\n\n For more information, refer to the [documentation](https://exercism.org/docs/building/tracks#h-avoiding-triggering-unnecessary-test-runs). If you are unsure whether to add the message or not, please ping `@exercism/maintainers-admin` in a comment. Thank you!"
             github.rest.issues.createComment({


### PR DESCRIPTION
Previously, the workflow did not explicitly pass in the GitHub token, which meant that commenting on PRs from forks wouldn't work. Fix that.

This commit reflects the [upstream change][1].

[1]: https://github.com/exercism/org-wide-files/commit/bfc6fe525e05