### PR TITLE
exercises(pangram) Improve testing for making behaviour compliant

### DIFF
--- a/exercises/practice/pangram/test_pangram.zig
+++ b/exercises/practice/pangram/test_pangram.zig
@@ -15,14 +15,6 @@ test "only lower case" {
     try testing.expect(pangram.isPangram("the quick brown fox jumps over the lazy dog"));
 }
 
-test "missing the letter 'x'" {
-    try testing.expect(!pangram.isPangram("a quick movement of the enemy will jeopardize five gunboats"));
-}
-
-test "missing the letter 'h'" {
-    try testing.expect(!pangram.isPangram("five boxing wizards jump quickly at it"));
-}
-
 test "with underscores" {
     try testing.expect(pangram.isPangram("the_quick_brown_fox_jumps_over_the_lazy_dog"));
 }
@@ -45,4 +37,29 @@ test "a-m and A-M are 26 different characters but not a pangram" {
 
 test "non-alphanumeric printable ASCII" {
     try testing.expect(!pangram.isPangram(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"));
+}
+
+test "test edge cases, missing an aplha at a time, plus whole ascii" {
+    var sequence: [256]u8 = undefined;
+
+    //fill in all ascii letters
+    inline for (0..sequence.len) |index| {
+        sequence[index] = @intCast(index);
+    }
+
+    const A_UPPER_START = 'A';
+    const A_LOWER_START = 'a';
+    const DISTANCE_z_a = 'z' - 'a';
+    for (0..DISTANCE_z_a + 1) |_offset| {
+        const pre_offset: u8 = @intCast(_offset);
+        sequence[pre_offset + A_UPPER_START] = 0;
+        sequence[pre_offset + A_LOWER_START] = 0;
+
+        try testing.expect(false == pangram.isPangram(&sequence));
+
+        //restore the nulled letter
+        sequence[pre_offset + A_UPPER_START] = A_UPPER_START + pre_offset;
+        sequence[pre_offset + A_LOWER_START] = A_LOWER_START + pre_offset;
+    }
+    try testing.expect(pangram.isPangram(&sequence));
 }


### PR DESCRIPTION
Currently, test cases do not prove a correct for behaviour implementation.

E.g. given  a-y or b-z, if an implementation considers those missing letters as existing, a program can perfectly pass     try testing.expect(pangram.isPangram("abcdefghijklmnopqrstuvwxyz"));

but not pass     try testing.expect(pangram.isPangram("abcdefghijklmnopqrstuvwxy"));

It is reproducible using a number as 26 bits to represent all alpha, where on the end it checks if the number is zero. 
Or writing a function that checks abcdefghijklmnopqrstuvwx, for example, returning true if those are in.


This commit adds a new test that address the problem mentioned and removes two tests that becomes irrelevant.

More tests can be removed with this addition, probably only the empty check is needed, but I am leaving it.