### PR TITLE
Update declaration of the binarySearch function.

### DIFF
--- a/exercises/practice/binary-search/binary_search.zig
+++ b/exercises/practice/binary-search/binary_search.zig
@@ -1,6 +1,6 @@
 // Take a look at the tests, you might have to change the function arguments
 
-pub fn binarySearch(target: usize, items: []const usize) ?usize {
+pub fn binarySearch(comptime T: type, target: usize, items: []const T) ?usize {
     _ = target;
     _ = items;
     @compileError("please implement the binarySearch function");


### PR DESCRIPTION
Problem: Previous declaration wasn't compatible with the tests:
```
test_binary_search.zig:10:20: error: expected 2 argument(s), found 3
    const actual = binarySearch(i4, 6, &array);
                   ^~~~~~~~~~~~
binary_search.zig:3:5: note: function declared here
```
Solution: declare the function properly.

Testing: with existing test cases