### PR TITLE
.github, docs: bump Zig from 0.12.0 to 0.13.0

### DIFF
--- a/.github/bin/install-zig
+++ b/.github/bin/install-zig
@@ -18,7 +18,7 @@ esac
 
 arch="$(uname -m)"
 
-version='0.12.0'
+version='0.13.0'
 url="https://ziglang.org/download/${version}/zig-${os}-${arch}-${version}.${ext}"
 
 curlopts=(

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,7 +5,7 @@ Fortunately, all of the popular installation methods are listed on the [Zig inst
 
 ## Zig version
 
-Exercism currently supports Zig 0.12.0 (released on 2024-04-20) only.
+Exercism currently supports Zig 0.13.0 (released on 2024-06-07) only.
 
 An exercise may be compatible with a different Zig version, but that isn't guaranteed.
 Zig has not yet reached version 1.0, and breaking changes are common.

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -4,4 +4,4 @@
 
 It may be helpful to look at the implementation of [`std.enums.EnumSet`][enumset].
 
-[enumset]: https://github.com/ziglang/zig/blob/0.12.0/lib/std/enums.zig#L243-L247
+[enumset]: https://github.com/ziglang/zig/blob/0.13.0/lib/std/enums.zig#L243-L247

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -13,6 +13,6 @@ For more details on hash maps in Zig, see:
 - [Zighelp - Hash Maps][zighelp]
 - [Zig Standard Library - `buf_set.zig`][buf-set]
 
-[buf-set]: https://github.com/ziglang/zig/blob/0.12.0/lib/std/buf_set.zig
+[buf-set]: https://github.com/ziglang/zig/blob/0.13.0/lib/std/buf_set.zig
 [zig-hashmaps-explained]: https://devlog.hexops.com/2022/zig-hashmaps-explained/
 [zighelp]: https://zighelp.org/chapter-2/#hash-maps

--- a/exercises/practice/perfect-numbers/.docs/instructions.append.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.append.md
@@ -8,6 +8,6 @@ For more details, see the [Zig Language Reference][zig-reference] and the implem
 
 However, note that this exercise does not currently test an input of 0 (because `std.testing` does [not yet support expecting a panic][proposal]).
 
-[zig-reference]: https://ziglang.org/documentation/0.12.0/#unreachable
-[assert]: https://github.com/ziglang/zig/blob/0.12.0/lib/std/debug.zig#L392-L404
+[zig-reference]: https://ziglang.org/documentation/0.13.0/#unreachable
+[assert]: https://github.com/ziglang/zig/blob/0.13.0/lib/std/debug.zig#L401-L413
 [proposal]: https://github.com/ziglang/zig/issues/1356


### PR DESCRIPTION
Zig 0.13.0 was released on 2024-06-07. See the [release notes][1].

This release comes shortly after 0.12.0 (2024-04-20), and is:

>primarily motivated by the fact that LLVM tagged their last 18.x release. To make it easier on package maintainers, we try to tag a Zig release shortly after LLVM.

Closes: https://github.com/exercism/zig/issues/409

[1]: https://ziglang.org/download/0.13.0/release-notes.html

---

We should merge this only after https://github.com/exercism/zig-test-runner/pull/98 is successfully deployed.