### PR TITLE
docs: update zig learning

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,7 +1,7 @@
 # Help
 
 - [The Zig Programming Language Documentation][documentation] is a great overview of all of the language features that Zig provides to those who use it.
-- [Zig Learn][zig-learn] is an excellent primer that explains the language features that Zig has to offer.
+- [Zig Guide][zig-guide] is an excellent primer that explains the language features that Zig has to offer.
 - [Ziglings][ziglings] is highly recommended.
   Learn Zig by fixing tiny broken programs.
 - [The Zig Programming Language Discord][discord-zig] is the main [Discord][discord].
@@ -16,5 +16,5 @@
 [irc]: https://webchat.freenode.net/?channels=%23zig
 [reddit]: https://www.reddit.com/r/Zig
 [stack-overflow]: https://stackoverflow.com/questions/tagged/zig
-[zig-learn]: https://ziglearn.org/
+[zig-guide]: https://zig.guide/
 [ziglings]: https://codeberg.org/ziglings/exercises


### PR DESCRIPTION
Regarding to archive.org[1] from 12:34:45 May 19, 2024, ziglearn.org has changed to http://zig.guide.

[1] web.archive.org/web/20240519123445/https://ziglearn.org/