### PR TITLE
practice/luhn: fix test

### DIFF
--- a/exercises/practice/luhn/test_luhn.zig
+++ b/exercises/practice/luhn/test_luhn.zig
@@ -16,7 +16,7 @@ test "a simple valid SIN that remains valid if reversed" {
 }
 
 test "a simple valid SIN that becomes invalid if reversed" {
-    try testing.expect(isValid("59"));
+    try testing.expect(!isValid("59"));
 }
 
 test "a valid Canadian SIN" {


### PR DESCRIPTION
The test  `"a simple valid SIN that becomes invalid if reversed"` should expect the number to be *invalid* but does the opposite. I just added the `!` for negating the expectation.

Based on the task, `059` is invalid as it sums up to `14` which is not evenly divisible by 10.