### PR TITLE
fix: update macOs workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   test-exercises:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
 
     name: Check exercises (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 14.

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612