### PR TITLE
Rename two exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
     "practice": [
       {
         "slug": "hello-world",
-        "name": "Hello, World!",
+        "name": "Hello World",
         "uuid": "25a0331e-612f-48c1-8a3f-9b0e9601a2fa",
         "practices": [
           "functions",
@@ -578,7 +578,7 @@
       },
       {
         "slug": "two-fer",
-        "name": "Two Fer",
+        "name": "Two-Fer",
         "uuid": "866a09d8-6949-4363-b83f-7b9fefb53893",
         "practices": [
           "conditionals",


### PR DESCRIPTION
Now all practice exercises have names consistent with problem-specifications metadata

https://github.com/exercism/problem-specifications/blob/main/exercises/hello-world/metadata.toml

https://github.com/exercism/problem-specifications/blob/main/exercises/two-fer/metadata.toml

[no important files changed]