### PR TITLE
Fixed missing imports on rotation cipher exercise stub

### DIFF
--- a/exercises/practice/rotational-cipher/rotational_cipher.zig
+++ b/exercises/practice/rotational-cipher/rotational_cipher.zig
@@ -1,3 +1,6 @@
+const std = @import("std");
+const mem = std.mem;
+
 pub fn rotate(allocator: mem.Allocator, text: []const u8, shiftKey: u5) mem.Allocator.Error![]u8 {
     _ = allocator;
     _ = text;


### PR DESCRIPTION
## Why?

Missing imports cause build to fail meaning you don't receive the more user friendly `@compileError("please implement the rotate function")`

## What?

Add missing imports required by function contract