### PR TITLE
Add missing std imports to show useful @compileError

### DIFF
--- a/exercises/practice/pig-latin/pig_latin.zig
+++ b/exercises/practice/pig-latin/pig_latin.zig
@@ -1,3 +1,6 @@
+const std = @import("std");
+const mem = std.mem;
+
 pub fn translate(allocator: mem.Allocator, phrase: []const u8) mem.Allocator.Error![]u8 {
     _ = allocator;
     _ = phrase;

--- a/exercises/practice/proverb/proverb.zig
+++ b/exercises/practice/proverb/proverb.zig
@@ -1,3 +1,7 @@
+const std = @import("std");
+const mem = std.mem;
+const fmt = std.fmt;
+
 pub fn recite(allocator: mem.Allocator, words: []const []const u8) (fmt.AllocPrintError || mem.Allocator.Error)![][]u8 {
     _ = allocator;
     _ = words;

--- a/exercises/practice/rna-transcription/rna_transcription.zig
+++ b/exercises/practice/rna-transcription/rna_transcription.zig
@@ -1,4 +1,5 @@
-// Import the appropriate standard library and modules
+const std = @import("std");
+const mem = std.mem;
 
 pub fn toRna(allocator: mem.Allocator, dna: []const u8) mem.Allocator.Error![]const u8 {
     _ = allocator;

--- a/exercises/practice/secret-handshake/secret_handshake.zig
+++ b/exercises/practice/secret-handshake/secret_handshake.zig
@@ -1,3 +1,7 @@
+const std = @import("std");
+const mem = std.mem;
+
+// An enum `Signal`, needs to be implemented.
 pub fn calculateHandshake(allocator: mem.Allocator, number: u5) mem.Allocator.Error![]const Signal {
     _ = allocator;
     _ = number;


### PR DESCRIPTION
## Why?

As raised in https://github.com/exercism/zig/pull/449 some exercises do not contain the imports needed for users to receive the nicer `@compileError` prompting them to implement the needed function.

## What?

Make exercise flagged by @keiravillekode more consistent by including imports as appropriate. Note, secret handshake will continue to fail for missing types as implementing `Signal` is part of the work required by the exercise.

https://github.com/exercism/zig/pull/449#issuecomment-2748517767