### PR TITLE
.github, docs, exercises: bump Zig from 0.13.0 to 0.14.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Zig
       uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f
       with:
-        version: 0.13.0
+        version: 0.14.1
 
     - name: Test exercises
       shell: bash

--- a/.github/workflows/zig-fmt.yml
+++ b/.github/workflows/zig-fmt.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Zig
       uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f
       with:
-        version: 0.13.0
+        version: 0.14.1
 
     - name: Check that Zig code is formatted
       run: |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,7 +5,7 @@ Fortunately, all of the popular installation methods are listed on the [Zig inst
 
 ## Zig version
 
-Exercism currently supports Zig 0.13.0 (released on 2024-06-07) only.
+Exercism currently supports Zig 0.14.1 (released on 2025-05-21) only.
 
 An exercise may be compatible with a different Zig version, but that isn't guaranteed.
 Zig has not yet reached version 1.0, and breaking changes are common.

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -4,4 +4,4 @@
 
 It may be helpful to look at the implementation of [`std.enums.EnumSet`][enumset].
 
-[enumset]: https://github.com/ziglang/zig/blob/0.13.0/lib/std/enums.zig#L243-L247
+[enumset]: https://github.com/ziglang/zig/blob/0.14.1/lib/std/enums.zig#L243-L247

--- a/exercises/practice/allergies/.meta/example.zig
+++ b/exercises/practice/allergies/.meta/example.zig
@@ -13,14 +13,14 @@ pub const Allergen = enum(u8) {
     cats = 128,
 };
 
-const tag_type = @typeInfo(Allergen).Enum.tag_type;
+const tag_type = @typeInfo(Allergen).@"enum".tag_type;
 
 pub fn isAllergicTo(score: tag_type, allergen: Allergen) bool {
     return score & @intFromEnum(allergen) != 0;
 }
 
 pub fn initAllergenSet(score: usize) EnumSet(Allergen) {
-    const len = @typeInfo(Allergen).Enum.fields.len;
+    const len = @typeInfo(Allergen).@"enum".fields.len;
     const bits = IntegerBitSet(len){ .mask = @as(tag_type, @truncate(score)) };
     return .{ .bits = bits };
 }

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -13,6 +13,6 @@ For more details on hash maps in Zig, see:
 - [Zighelp - Hash Maps][zighelp]
 - [Zig Standard Library - `buf_set.zig`][buf-set]
 
-[buf-set]: https://github.com/ziglang/zig/blob/0.13.0/lib/std/buf_set.zig
+[buf-set]: https://github.com/ziglang/zig/blob/0.14.1/lib/std/buf_set.zig
 [zig-hashmaps-explained]: https://devlog.hexops.com/2022/zig-hashmaps-explained/
 [zighelp]: https://zighelp.org/chapter-2/#hash-maps

--- a/exercises/practice/dnd-character/.meta/example.zig
+++ b/exercises/practice/dnd-character/.meta/example.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-var prng = std.rand.DefaultPrng.init(42);
+var prng = std.Random.DefaultPrng.init(42);
 const random = prng.random();
 
 pub fn ability() u8 {

--- a/exercises/practice/perfect-numbers/.docs/instructions.append.md
+++ b/exercises/practice/perfect-numbers/.docs/instructions.append.md
@@ -8,6 +8,6 @@ For more details, see the [Zig Language Reference][zig-reference] and the implem
 
 However, note that this exercise does not currently test an input of 0 (because `std.testing` does [not yet support expecting a panic][proposal]).
 
-[zig-reference]: https://ziglang.org/documentation/0.13.0/#unreachable
-[assert]: https://github.com/ziglang/zig/blob/0.13.0/lib/std/debug.zig#L401-L413
+[zig-reference]: https://ziglang.org/documentation/0.14.1/#unreachable
+[assert]: https://github.com/ziglang/zig/blob/0.14.1/lib/std/debug.zig#L536-L551
 [proposal]: https://github.com/ziglang/zig/issues/1356

--- a/exercises/practice/yacht/.meta/example.zig
+++ b/exercises/practice/yacht/.meta/example.zig
@@ -19,7 +19,7 @@ const DiceInt = u3;
 const Dice = [5]DiceInt;
 
 /// Returns the sum of the items in `dice` that equal `n`.
-fn sumOnly(dice: Dice, n: @typeInfo(Category).Enum.tag_type) u32 {
+fn sumOnly(dice: Dice, n: @typeInfo(Category).@"enum".tag_type) u32 {
     var result: u32 = 0;
     for (dice) |d| {
         if (d == n) result += n;


### PR DESCRIPTION
See the [release notes for Zig 0.14.0][1].

The reflected breaking changes are, quoting from those release notes:

>- `std.rand` ([renamed][2] to `std.Random`)
>
>- Zig 0.14.0 [updates][3] the fields of the `std.builtin.Type` tagged union to follow these conventions by lowercasing them.
>[...]
>Note that this requires using "quoted identifier" syntax for `@"struct"`, `@"union"`, `@"enum"`, `@"opaque"`, and `@"anyframe"`, because these identifiers are also keywords.

[1]: https://ziglang.org/download/0.14.0/release-notes.html
[2]: https://ziglang.org/download/0.14.0/release-notes.html#List-of-Deprecations
[3]: https://ziglang.org/download/0.14.0/release-notes.html#stdbuiltinType-Fields-Renamed

---

Previous bump: https://github.com/exercism/zig/pull/410

To-do:

- [x] Update the Zig code in the exercises to reflect the breaking changes.
- [x] Update links to point to Zig 0.14.1.
- [x] Ensure that this PR is merged at the same time as the [corresponding PR](https://github.com/exercism/zig-test-runner/pull/126) in the `exercism/zig-test-runner` repo. Please let me merge both. We should merge this only after the Zig 0.14.1 image is successfully deployed on Exercism.

I'll deliberately keep this PR as a draft for now to indicate that it's not ready to be merged. However, it is ready for review.