### PR TITLE
food-chain,house,twelve-days error reporting

### DIFF
--- a/exercises/practice/food-chain/.docs/instructions.append.md
+++ b/exercises/practice/food-chain/.docs/instructions.append.md
@@ -1,0 +1,8 @@
+# Instructions append
+
+## Detect invalid input
+
+Use [std.debug.assert][assert] or return an [error][error].
+
+[error]: https://ziglang.org/documentation/master/#Errors
+[assert]: https://ziglang.org/documentation/master/std/#std.debug.assert

--- a/exercises/practice/food-chain/.meta/example.zig
+++ b/exercises/practice/food-chain/.meta/example.zig
@@ -29,7 +29,10 @@ fn appendString(buffer: []u8, offset: *usize, str: []const u8) void {
     offset.* += str.len;
 }
 
-pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) []const u8 {
+pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) ![]const u8 {
+    std.debug.assert(start_verse >= 1);
+    std.debug.assert(end_verse >= start_verse);
+    std.debug.assert(end_verse <= 8);
     var offset: usize = 0;
 
     for (start_verse..(end_verse + 1)) |verse| {

--- a/exercises/practice/food-chain/food_chain.zig
+++ b/exercises/practice/food-chain/food_chain.zig
@@ -1,4 +1,4 @@
-pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) []const u8 {
+pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) ![]const u8 {
     _ = buffer;
     _ = start_verse;
     _ = end_verse;

--- a/exercises/practice/food-chain/test_food_chain.zig
+++ b/exercises/practice/food-chain/test_food_chain.zig
@@ -10,7 +10,7 @@ test "fly" {
         \\I know an old lady who swallowed a fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 1, 1);
+    const actual = try food_chain.recite(&buffer, 1, 1);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -23,7 +23,7 @@ test "spider" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 2, 2);
+    const actual = try food_chain.recite(&buffer, 2, 2);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -37,7 +37,7 @@ test "bird" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 3, 3);
+    const actual = try food_chain.recite(&buffer, 3, 3);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -52,7 +52,7 @@ test "cat" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 4, 4);
+    const actual = try food_chain.recite(&buffer, 4, 4);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -68,7 +68,7 @@ test "dog" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 5, 5);
+    const actual = try food_chain.recite(&buffer, 5, 5);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -85,7 +85,7 @@ test "goat" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 6, 6);
+    const actual = try food_chain.recite(&buffer, 6, 6);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -103,7 +103,7 @@ test "cow" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 7, 7);
+    const actual = try food_chain.recite(&buffer, 7, 7);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -114,7 +114,7 @@ test "horse" {
         \\I know an old lady who swallowed a horse.
         \\She's dead, of course!
     ;
-    const actual = food_chain.recite(&buffer, 8, 8);
+    const actual = try food_chain.recite(&buffer, 8, 8);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -136,7 +136,7 @@ test "multiple verses" {
         \\She swallowed the spider to catch the fly.
         \\I don't know why she swallowed the fly. Perhaps she'll die.
     ;
-    const actual = food_chain.recite(&buffer, 1, 3);
+    const actual = try food_chain.recite(&buffer, 1, 3);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -195,6 +195,6 @@ test "full song" {
         \\I know an old lady who swallowed a horse.
         \\She's dead, of course!
     ;
-    const actual = food_chain.recite(&buffer, 1, 8);
+    const actual = try food_chain.recite(&buffer, 1, 8);
     try testing.expectEqualStrings(expected, actual);
 }

--- a/exercises/practice/house/.docs/instructions.append.md
+++ b/exercises/practice/house/.docs/instructions.append.md
@@ -1,0 +1,8 @@
+# Instructions append
+
+## Detect invalid input
+
+Use [std.debug.assert][assert] or return an [error][error].
+
+[error]: https://ziglang.org/documentation/master/#Errors
+[assert]: https://ziglang.org/documentation/master/std/#std.debug.assert

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": [],
+  "authors": [
+    "keiravillekode"
+  ],
   "files": {
     "solution": [
       "house.zig"

--- a/exercises/practice/house/.meta/example.zig
+++ b/exercises/practice/house/.meta/example.zig
@@ -11,7 +11,10 @@ fn appendString(buffer: []u8, offset: *usize, str: []const u8) void {
     offset.* += str.len;
 }
 
-pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) []const u8 {
+pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) ![]const u8 {
+    std.debug.assert(start_verse >= 1);
+    std.debug.assert(end_verse >= start_verse);
+    std.debug.assert(end_verse <= 12);
     var offset: usize = 0;
 
     for (start_verse..(end_verse + 1)) |verse| {

--- a/exercises/practice/house/house.zig
+++ b/exercises/practice/house/house.zig
@@ -1,4 +1,4 @@
-pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) []const u8 {
+pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) ![]const u8 {
     _ = buffer;
     _ = start_verse;
     _ = end_verse;

--- a/exercises/practice/house/test_house.zig
+++ b/exercises/practice/house/test_house.zig
@@ -9,7 +9,7 @@ test "verse one - the house that jack built" {
     const expected: []const u8 =
         \\This is the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 1, 1);
+    const actual = try house.recite(&buffer, 1, 1);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -19,7 +19,7 @@ test "verse two - the malt that lay" {
     const expected: []const u8 =
         \\This is the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 2, 2);
+    const actual = try house.recite(&buffer, 2, 2);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -29,7 +29,7 @@ test "verse three - the rat that ate" {
     const expected: []const u8 =
         \\This is the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 3, 3);
+    const actual = try house.recite(&buffer, 3, 3);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -39,7 +39,7 @@ test "verse four - the cat that killed" {
     const expected: []const u8 =
         \\This is the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 4, 4);
+    const actual = try house.recite(&buffer, 4, 4);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -49,7 +49,7 @@ test "verse five - the dog that worried" {
     const expected: []const u8 =
         \\This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 5, 5);
+    const actual = try house.recite(&buffer, 5, 5);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -59,7 +59,7 @@ test "verse six - the cow with the crumpled horn" {
     const expected: []const u8 =
         \\This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 6, 6);
+    const actual = try house.recite(&buffer, 6, 6);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -69,7 +69,7 @@ test "verse seven - the maiden all forlorn" {
     const expected: []const u8 =
         \\This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 7, 7);
+    const actual = try house.recite(&buffer, 7, 7);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -79,7 +79,7 @@ test "verse eight - the man all tattered and torn" {
     const expected: []const u8 =
         \\This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 8, 8);
+    const actual = try house.recite(&buffer, 8, 8);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -89,7 +89,7 @@ test "verse nine - the priest all shaven and shorn" {
     const expected: []const u8 =
         \\This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 9, 9);
+    const actual = try house.recite(&buffer, 9, 9);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -99,7 +99,7 @@ test "verse 10 - the rooster that crowed in the morn" {
     const expected: []const u8 =
         \\This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 10, 10);
+    const actual = try house.recite(&buffer, 10, 10);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -109,7 +109,7 @@ test "verse 11 - the farmer sowing his corn" {
     const expected: []const u8 =
         \\This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 11, 11);
+    const actual = try house.recite(&buffer, 11, 11);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -119,7 +119,7 @@ test "verse 12 - the horse and the hound and the horn" {
     const expected: []const u8 =
         \\This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 12, 12);
+    const actual = try house.recite(&buffer, 12, 12);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -133,7 +133,7 @@ test "multiple verses" {
         \\This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
         \\This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 4, 8);
+    const actual = try house.recite(&buffer, 4, 8);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -154,6 +154,6 @@ test "full rhyme" {
         \\This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
         \\This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.
     ;
-    const actual = house.recite(&buffer, 1, 12);
+    const actual = try house.recite(&buffer, 1, 12);
     try testing.expectEqualStrings(expected, actual);
 }

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,0 +1,8 @@
+# Instructions append
+
+## Detect invalid input
+
+Use [std.debug.assert][assert] or return an [error][error].
+
+[error]: https://ziglang.org/documentation/master/#Errors
+[assert]: https://ziglang.org/documentation/master/std/#std.debug.assert

--- a/exercises/practice/twelve-days/.meta/example.zig
+++ b/exercises/practice/twelve-days/.meta/example.zig
@@ -15,7 +15,10 @@ fn appendString(buffer: []u8, offset: *usize, str: []const u8) void {
     offset.* += str.len;
 }
 
-pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) []const u8 {
+pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) ![]const u8 {
+    std.debug.assert(start_verse >= 1);
+    std.debug.assert(end_verse >= start_verse);
+    std.debug.assert(end_verse <= 12);
     var offset: usize = 0;
 
     for (start_verse..(end_verse + 1)) |verse| {

--- a/exercises/practice/twelve-days/test_twelve_days.zig
+++ b/exercises/practice/twelve-days/test_twelve_days.zig
@@ -9,7 +9,7 @@ test "verse-first day a partridge in a pear tree" {
     const expected: []const u8 =
         \\On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 1, 1);
+    const actual = try twelve_days.recite(&buffer, 1, 1);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -19,7 +19,7 @@ test "verse-second day two turtle doves" {
     const expected: []const u8 =
         \\On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 2, 2);
+    const actual = try twelve_days.recite(&buffer, 2, 2);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -29,7 +29,7 @@ test "verse-third day three french hens" {
     const expected: []const u8 =
         \\On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 3, 3);
+    const actual = try twelve_days.recite(&buffer, 3, 3);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -39,7 +39,7 @@ test "verse-fourth day four calling birds" {
     const expected: []const u8 =
         \\On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 4, 4);
+    const actual = try twelve_days.recite(&buffer, 4, 4);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -49,7 +49,7 @@ test "verse-fifth day five gold rings" {
     const expected: []const u8 =
         \\On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 5, 5);
+    const actual = try twelve_days.recite(&buffer, 5, 5);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -59,7 +59,7 @@ test "verse-sixth day six geese-a-laying" {
     const expected: []const u8 =
         \\On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 6, 6);
+    const actual = try twelve_days.recite(&buffer, 6, 6);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -69,7 +69,7 @@ test "verse-seventh day seven swans-a-swimming" {
     const expected: []const u8 =
         \\On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 7, 7);
+    const actual = try twelve_days.recite(&buffer, 7, 7);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -79,7 +79,7 @@ test "verse-eighth day eight maids-a-milking" {
     const expected: []const u8 =
         \\On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 8, 8);
+    const actual = try twelve_days.recite(&buffer, 8, 8);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -89,7 +89,7 @@ test "verse-ninth day nine ladies dancing" {
     const expected: []const u8 =
         \\On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 9, 9);
+    const actual = try twelve_days.recite(&buffer, 9, 9);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -99,7 +99,7 @@ test "verse-tenth day ten lords-a-leaping" {
     const expected: []const u8 =
         \\On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 10, 10);
+    const actual = try twelve_days.recite(&buffer, 10, 10);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -109,7 +109,7 @@ test "verse-eleventh day eleven pipers piping" {
     const expected: []const u8 =
         \\On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 11, 11);
+    const actual = try twelve_days.recite(&buffer, 11, 11);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -119,7 +119,7 @@ test "verse-twelfth day twelve drummers drumming" {
     const expected: []const u8 =
         \\On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 12, 12);
+    const actual = try twelve_days.recite(&buffer, 12, 12);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -131,7 +131,7 @@ test "lyrics-recites first three verses of the song" {
         \\On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.
         \\On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 1, 3);
+    const actual = try twelve_days.recite(&buffer, 1, 3);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -143,7 +143,7 @@ test "lyrics-recites three verses from the middle of the song" {
         \\On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
         \\On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 4, 6);
+    const actual = try twelve_days.recite(&buffer, 4, 6);
     try testing.expectEqualStrings(expected, actual);
 }
 
@@ -164,6 +164,6 @@ test "lyrics-recites the whole song" {
         \\On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
         \\On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
     ;
-    const actual = twelve_days.recite(&buffer, 1, 12);
+    const actual = try twelve_days.recite(&buffer, 1, 12);
     try testing.expectEqualStrings(expected, actual);
 }

--- a/exercises/practice/twelve-days/twelve_days.zig
+++ b/exercises/practice/twelve-days/twelve_days.zig
@@ -1,4 +1,4 @@
-pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) []const u8 {
+pub fn recite(buffer: []u8, start_verse: u32, end_verse: u32) ![]const u8 {
     _ = buffer;
     _ = start_verse;
     _ = end_verse;


### PR DESCRIPTION
We allow errors to be returned from recite()

This change breaks existing community solutions.