### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/eliuds-eggs/.docs/instructions.append.md
+++ b/exercises/practice/eliuds-eggs/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Avoid using [builtin functions](https://ziglang.org/documentation/master/#Builtin-Functions) for this exercise.

--- a/exercises/practice/micro-blog/.docs/instructions.append.md
+++ b/exercises/practice/micro-blog/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 You may assume the input is valid [UTF-8][utf-8].
 
 [utf-8]: https://en.wikipedia.org/wiki/UTF-8

--- a/exercises/practice/rail-fence-cipher/.docs/instructions.append.md
+++ b/exercises/practice/rail-fence-cipher/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 You may assume there are at least two rails.

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Any instructions other than R, L and A may be ignored.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.